### PR TITLE
copy test_field and test_schema from python lib (+ implemented related functionality)

### DIFF
--- a/src/Fields/BaseField.php
+++ b/src/Fields/BaseField.php
@@ -16,6 +16,14 @@ abstract class BaseField
         return $this->descriptor;
     }
 
+    public function fullDescriptor()
+    {
+        $fullDescriptor = $this->descriptor();
+        $fullDescriptor->format = $this->format();
+        $fullDescriptor->type = $this->type();
+        return $fullDescriptor;
+    }
+
     public function name()
     {
         return $this->descriptor()->name;

--- a/src/Fields/IntegerField.php
+++ b/src/Fields/IntegerField.php
@@ -8,8 +8,9 @@ class IntegerField extends BaseField
      * @return integer
      * @throws \frictionlessdata\tableschema\Exceptions\FieldValidationException;
      */
-    public function validateValue($val)
+    public function validateCastValue($val)
     {
+        $val = parent::validateCastValue($val);
         if (!is_numeric($val)) {
             throw $this->getValidationException("value must be numeric", $val);
         } else {
@@ -25,5 +26,10 @@ class IntegerField extends BaseField
     public static function type()
     {
         return "integer";
+    }
+
+    protected function isEmptyValue($val)
+    {
+        return (!is_numeric($val) && empty($val));
     }
 }

--- a/src/Fields/NumberField.php
+++ b/src/Fields/NumberField.php
@@ -8,8 +8,9 @@ class NumberField extends BaseField
      * @return float
      * @throws \frictionlessdata\tableschema\Exceptions\FieldValidationException;
      */
-    public function validateValue($val)
+    public function validateCastValue($val)
     {
+        $val = parent::validateCastValue($val);
         if (!is_numeric($val)) {
             throw $this->getValidationException("value must be numeric", $val);
         } else {
@@ -20,5 +21,10 @@ class NumberField extends BaseField
     public static function type()
     {
         return "number";
+    }
+
+    protected function isEmptyValue($val)
+    {
+        return (!is_numeric($val) && empty($val));
     }
 }

--- a/src/Fields/StringField.php
+++ b/src/Fields/StringField.php
@@ -5,11 +5,6 @@ use frictionlessdata\tableschema\Exceptions\FieldValidationException;
 
 class StringField extends BaseField
 {
-    public function format()
-    {
-        return isset($this->descriptor()->format) ? $this->descriptor()->format : null;
-    }
-
     public function inferProperties($val, $lenient=false)
     {
         parent::inferProperties($val, $lenient);
@@ -25,8 +20,9 @@ class StringField extends BaseField
      * @return string
      * @throws \frictionlessdata\tableschema\Exceptions\FieldValidationException;
      */
-    public function validateValue($val)
+    public function validateCastValue($val)
     {
+        $val = parent::validateCastValue($val);
         if ($this->format() == "email" && strpos($val, "@") === false) {
             throw $this->getValidationException("value is not a valid email", $val);
         } else {
@@ -47,5 +43,15 @@ class StringField extends BaseField
             $inferId .= ":".$this->format();
         };
         return $inferId;
+    }
+
+    protected function checkMinimumConstraint($val, $minConstraint)
+    {
+        throw $this->getValidationException("minimum constraint is not supported for string fields", $val);
+    }
+
+    protected function checkMaximumConstraint($val, $maxConstraint)
+    {
+        throw $this->getValidationException("maximum constraint is not supported for string fields", $val);
     }
 }

--- a/src/InferSchema.php
+++ b/src/InferSchema.php
@@ -6,6 +6,11 @@ namespace frictionlessdata\tableschema;
  */
 class InferSchema extends Schema
 {
+    /**
+     * InferSchema constructor.
+     * @param null $descriptor optional descriptor object - will be used as an initial descriptor
+     * @param bool $lenient if true - infer just basic types, without strict format requirements
+     */
     public function __construct($descriptor=null, $lenient=false)
     {
         $this->descriptor = empty($descriptor) ? (object)["fields" => []] : $descriptor;

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -91,27 +91,30 @@ class Schema
 
     public function field($name)
     {
-        foreach ($this->fields() as $field) {
-            if ($field->name() == $name) return $field;
+        $fields = $this->fields();
+        if (array_key_exists($name, $fields)) {
+            return $fields[$name];
+        } else {
+            throw new \Exception("unknown field name: {$name}");
         }
-        throw new \Exception("unknown field name: {$name}");
     }
 
     /**
-     * @return Fields\BaseField[]
+     * @return Fields\BaseField[] array of field name => field object
      */
     public function fields()
     {
-        $fields = [];
-        foreach ($this->descriptor()->fields as $fieldDescriptor) {
-            if (!array_key_exists("type", $fieldDescriptor)) {
-                $field = new $this->DEFAULT_FIELD_CLASS($fieldDescriptor);
-            } else {
-                $field = Fields\FieldsFactory::field($fieldDescriptor);
+        if (empty($this->fieldsCache)) {
+            foreach ($this->descriptor()->fields as $fieldDescriptor) {
+                if (!array_key_exists("type", $fieldDescriptor)) {
+                    $field = new $this->DEFAULT_FIELD_CLASS($fieldDescriptor);
+                } else {
+                    $field = Fields\FieldsFactory::field($fieldDescriptor);
+                }
+                $this->fieldsCache[$field->name()] = $field;
             }
-            $fields[$field->name()] = $field;
         }
-        return $fields;
+        return $this->fieldsCache;
     }
 
     public function missingValues()
@@ -173,4 +176,5 @@ class Schema
     }
 
     protected $descriptor;
+    protected $fieldsCache = null;
 }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -75,6 +75,14 @@ class Schema
         return $this->descriptor;
     }
 
+    public function field($name)
+    {
+        foreach ($this->fields() as $field) {
+            if ($field->name() == $name) return $field;
+        }
+        throw new \Exception("unknown field name: {$name}");
+    }
+
     /**
      * @return Fields\BaseField[]
      */
@@ -91,6 +99,11 @@ class Schema
     public function missingValues()
     {
         return isset($this->descriptor()->missingValues) ? $this->descriptor()->missingValues : [];
+    }
+
+    public function primaryKey()
+    {
+        return isset($this->descriptor()->primaryKey) ? $this->descriptor()->primaryKey : [];
     }
 
     /**

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -75,6 +75,9 @@ class Schema
         return $this->descriptor;
     }
 
+    /**
+     * @return Fields\BaseField[]
+     */
     public function fields()
     {
         $fields = [];
@@ -83,6 +86,11 @@ class Schema
             $fields[$field->name()] = $field;
         }
         return $fields;
+    }
+
+    public function missingValues()
+    {
+        return isset($this->descriptor()->missingValues) ? $this->descriptor()->missingValues : [];
     }
 
     /**
@@ -96,6 +104,7 @@ class Schema
         $validationErrors = [];
         foreach ($this->fields() as $fieldName => $field) {
             $value = array_key_exists($fieldName, $row) ? $row[$fieldName] : null;
+            if (in_array($value, $this->missingValues())) $value = null;
             try {
                 $outRow[$fieldName] = $field->castValue($value);
             } catch (Exceptions\FieldValidationException $e) {

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -49,9 +49,11 @@ class SchemaValidator
     {
         // Validate
         $validator = new \JsonSchema\Validator();
+        $descriptor = json_decode(json_encode($this->descriptor));
+        $this->applyForeignKeysResourceHack($descriptor);
         $validator->validate(
-            $this->descriptor,
-                (object)['$ref' => 'file://' . realpath(dirname(__FILE__)).'/schemas/table-schema.json']
+            $descriptor,
+            (object)['$ref' => 'file://' . realpath(dirname(__FILE__)).'/schemas/table-schema.json']
         );
         if (!$validator->isValid()) {
             foreach ($validator->getErrors() as $error) {
@@ -59,6 +61,21 @@ class SchemaValidator
                     SchemaValidationError::SCHEMA_VIOLATION,
                     sprintf("[%s] %s", $error['property'], $error['message'])
                 );
+            }
+        }
+    }
+
+    protected function applyForeignKeysResourceHack($descriptor)
+    {
+        if (isset($descriptor->foreignKeys) && is_array($descriptor->foreignKeys)) {
+            foreach ($descriptor->foreignKeys as $foreignKey) {
+                if (
+                    is_object($foreignKey)
+                    && isset($foreignKey->reference) && is_object($foreignKey->reference)
+                    && isset($foreignKey->reference->resource) && empty($foreignKey->reference->resource)
+                ) {
+                    $foreignKey->reference->resource = "self";
+                }
             }
         }
     }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -1,0 +1,322 @@
+<?php
+namespace frictionlessdata\tableschema\tests;
+
+use frictionlessdata\tableschema\DataSources\NativeDataSource;
+use frictionlessdata\tableschema\Exceptions\DataSourceException;
+use frictionlessdata\tableschema\Exceptions\FieldValidationException;
+use frictionlessdata\tableschema\Schema;
+use frictionlessdata\tableschema\SchemaValidationError;
+use frictionlessdata\tableschema\Table;
+use PHPUnit\Framework\TestCase;
+use frictionlessdata\tableschema\Fields\FieldsFactory;
+
+class FieldTest extends TestCase
+{
+    public $DESCRIPTOR_WITHOUT_TYPE;
+    public $DESCRIPTOR_MIN;
+    public $DESCRIPTOR_MAX;
+
+    public function setUp()
+    {
+        $this->DESCRIPTOR_WITHOUT_TYPE = (object)[
+            "name" => "id"
+        ];
+        $this->DESCRIPTOR_MIN = (object)[
+            "name" => "id",
+            "type" => "string"
+        ];
+        $this->DESCRIPTOR_MAX = (object)[
+            "name" => "id",
+            "type" => "integer",
+            "format" => "default",
+            "constraints" => (object)["required" => true]
+        ];
+    }
+
+    public function testNoValidFieldType()
+    {
+        try {
+            FieldsFactory::field($this->DESCRIPTOR_WITHOUT_TYPE);
+            $this->fail();
+        } catch (FieldValidationException $e) {
+            $this->assertEquals('Could not find a valid field for descriptor: {"name":"id"}', $e->getMessage());
+        }
+    }
+
+    public function testDescriptor()
+    {
+        $this->assertEquals(
+            $this->DESCRIPTOR_MIN,
+            FieldsFactory::field($this->DESCRIPTOR_MIN)->descriptor()
+        );
+    }
+
+    public function testName()
+    {
+        $this->assertEquals("id", FieldsFactory::field($this->DESCRIPTOR_MIN)->name());
+    }
+
+    public function testType()
+    {
+        $this->assertEquals("string", FieldsFactory::field($this->DESCRIPTOR_MIN)->type());
+        $this->assertEquals("integer", FieldsFactory::field($this->DESCRIPTOR_MAX)->type());
+    }
+
+    public function testFormat()
+    {
+        $this->assertEquals("default", FieldsFactory::field($this->DESCRIPTOR_MIN)->format());
+        $this->assertEquals("default", FieldsFactory::field($this->DESCRIPTOR_MAX)->format());
+    }
+
+    public function testConstraints()
+    {
+        $this->assertEquals((object)[], FieldsFactory::field($this->DESCRIPTOR_MIN)->constraints());
+        $this->assertEquals((object)["required" => True], FieldsFactory::field($this->DESCRIPTOR_MAX)->constraints());
+    }
+
+    public function testRequired()
+    {
+        $this->assertEquals(false, FieldsFactory::field($this->DESCRIPTOR_MIN)->required());
+        $this->assertEquals(true, FieldsFactory::field($this->DESCRIPTOR_MAX)->required());
+    }
+
+    public function testCastValue()
+    {
+        $this->assertEquals(1, FieldsFactory::field($this->DESCRIPTOR_MAX)->castValue("1"));
+    }
+
+    public function testCastValueConstraintError()
+    {
+        try {
+            FieldsFactory::field($this->DESCRIPTOR_MAX)->castValue("");
+            $this->fail();
+        } catch (FieldValidationException $e) {
+            $this->assertEquals('id: field is required ()', $e->getMessage());
+        }
+    }
+
+    public function testDisableConstraints()
+    {
+        $this->assertEquals(
+            null,
+            FieldsFactory::field($this->DESCRIPTOR_MIN)->disableConstraints()->castValue("")
+        );
+        $this->assertEquals(
+            null,
+            FieldsFactory::field($this->DESCRIPTOR_MAX)->disableConstraints()->castValue("")
+        );
+    }
+
+    public function testCastValueNullMissingValues()
+    {
+        // missing values are only validated at schema castRow function
+        $schema = new Schema((object)[
+            "fields" => [
+                (object)["name" => "name", "type" => "number"]
+            ],
+            "missingValues" => ["null"]
+        ]);
+        $this->assertEquals(["name" => null], $schema->castRow(["name" => "null"]));
+    }
+
+    public function testValidateValue()
+    {
+        $this->assertFieldValidateValue("", $this->DESCRIPTOR_MAX, "1");
+        $this->assertFieldValidateValue('id: value must be numeric (string)', $this->DESCRIPTOR_MAX, "string");
+        $this->assertFieldValidateValue('id: field is required ()', $this->DESCRIPTOR_MAX, "");
+    }
+
+    public function testValidateValueDisableConstraints()
+    {
+        $this->assertEquals([], FieldsFactory::field($this->DESCRIPTOR_MIN)->disableConstraints()->validateValue(""));
+        $this->assertEquals([], FieldsFactory::field($this->DESCRIPTOR_MAX)->disableConstraints()->validateValue(""));
+    }
+
+    public function testStringMissingValues()
+    {
+        $this->assertMissingValues(["type" => "string"], ["", "NA", "N/A"]);
+    }
+
+    public function testNumberMissingValues()
+    {
+        $this->assertMissingValues(["type" => "number"], ["", "NA", "N/A"]);
+    }
+
+    public function testValidateValueRequired()
+    {
+        $schema = new Schema((object)[
+            "fields" => [
+                (object)[
+                    "name" => "name",
+                    "type" => "string",
+                    "constraints" => (object)["required" => true]
+                ]
+            ],
+            "missingValues" => ["", "NA", "N/A"]
+        ]);
+        $this->assertSchemaValidateValue("", $schema, "test");
+        $this->assertSchemaValidateValue("", $schema, "null");
+        $this->assertSchemaValidateValue("", $schema, "none");
+        $this->assertSchemaValidateValue("", $schema, "nil");
+        $this->assertSchemaValidateValue("", $schema, "nan");
+        $this->assertSchemaValidateValue('name: field is required ()', $schema, "NA");
+        $this->assertSchemaValidateValue('name: field is required ()', $schema, "N/A");
+        $this->assertSchemaValidateValue("", $schema, "-");
+        $this->assertSchemaValidateValue('name: field is required ()', $schema, "");
+        $this->assertSchemaValidateValue('name: field is required ()', $schema, null);
+    }
+
+    public function testValidateValuePattern()
+    {
+        $descriptor = (object)[
+            "name" => "name",
+            "type" => "string",
+            "constraints" => (object)["pattern" => "3.*"]
+        ];
+        $this->assertFieldValidateValue("", $descriptor, "3");
+        $this->assertFieldValidateValue("", $descriptor, "321");
+        $this->assertFieldValidateValue("name: value does not match pattern (123)", $descriptor, "123");
+    }
+
+    public function testValidateValueUnique()
+    {
+        // unique values are only validated at the Table object
+        $dataSource = new NativeDataSource([
+            ["name" => 1],
+            ["name" => 2],
+            ["name" => 2],
+            ["name" => 4]
+        ]);
+        $schema = new Schema((object)[
+            "fields" => [
+                (object)[
+                    "name" => "name",
+                    "type" => "integer",
+                    "constraints" => (object)["unique" => true]
+                ]
+            ]
+        ]);
+        $table = new Table($dataSource, $schema);
+        $actualRows = [];
+        try {
+            foreach ($table as $row) {
+                $actualRows[] = $row;
+            }
+            $this->fail();
+        } catch (DataSourceException $e) {
+            $this->assertEquals([
+                ["name" => 1],
+                ["name" => 2]
+            ], $actualRows);
+            $this->assertEquals('row 3: field must be unique', $e->getMessage());
+        }
+    }
+
+    public function testValidateValueEnum()
+    {
+        $descriptor = (object)[
+            "name" => "name",
+            "type" => "integer",
+            "constraints" => (object)["enum" => ["1", "2", 3]]
+        ];
+        $this->assertFieldValidateValue("", $descriptor, "1");
+        $this->assertFieldValidateValue("", $descriptor, 2);
+        $this->assertFieldValidateValue("", $descriptor, "3");
+        $this->assertFieldValidateValue("name: value not in enum (4)", $descriptor, "4");
+        $this->assertFieldValidateValue("name: value not in enum (4)", $descriptor, 4);
+    }
+
+    public function testValidateValueMinimum()
+    {
+        $descriptor = (object)[
+            "name" => "name",
+            "type" => "integer",
+            "constraints" => (object)["minimum" => 1]
+        ];
+        $this->assertFieldValidateValue("", $descriptor, "2");
+        $this->assertFieldValidateValue("", $descriptor, 2);
+        $this->assertFieldValidateValue("", $descriptor, "1");
+        $this->assertFieldValidateValue("", $descriptor, 1);
+        $this->assertFieldValidateValue("name: value is below minimum (0)", $descriptor, "0");
+        $this->assertFieldValidateValue("name: value is below minimum (0)", $descriptor, 0);
+    }
+
+    public function testValidateValueMaximum()
+    {
+        $descriptor = (object)[
+            "name" => "name",
+            "type" => "integer",
+            "constraints" => (object)["maximum" => 1]
+        ];
+        $this->assertFieldValidateValue("", $descriptor, "0");
+        $this->assertFieldValidateValue("", $descriptor, 0);
+        $this->assertFieldValidateValue("", $descriptor, "1");
+        $this->assertFieldValidateValue("", $descriptor, 1);
+        $this->assertFieldValidateValue("name: value is above maximum (2)", $descriptor, "2");
+        $this->assertFieldValidateValue("name: value is above maximum (2)", $descriptor, 2);
+    }
+
+    public function testValidateValueMinLength()
+    {
+        $descriptor = (object)[
+            "name" => "name",
+            "type" => "string",
+            "constraints" => (object)["minLength" => 2]
+        ];
+        $this->assertFieldValidateValue("", $descriptor, "ab");
+        $this->assertFieldValidateValue("", $descriptor, "aaaa");
+        // null value passes (because field is not required)
+        $this->assertFieldValidateValue("", $descriptor, null);
+        $this->assertFieldValidateValue("name: value is below minimum length (a)", $descriptor, "a");
+    }
+
+    public function testValidateValueMaxLength()
+    {
+        $descriptor = (object)[
+            "name" => "name",
+            "type" => "string",
+            "constraints" => (object)["maxLength" => 2]
+        ];
+        $this->assertFieldValidateValue("", $descriptor, "ab");
+        $this->assertFieldValidateValue("", $descriptor, "a");
+        $this->assertFieldValidateValue("", $descriptor, null);
+        $this->assertFieldValidateValue("", $descriptor, "");
+        $this->assertFieldValidateValue("name: value is above maximum length (aaa)", $descriptor, "aaa");
+    }
+
+    protected function assertFieldValidateValue($expectedErrors, $descriptor, $value)
+    {
+        $this->assertEquals(
+            $expectedErrors,
+            SchemaValidationError::getErrorMessages(FieldsFactory::field($descriptor)->validateValue($value))
+        );
+    }
+
+    /**
+     * @param $expectedErrors
+     * @param $schema Schema
+     * @param $value
+     */
+    protected function assertSchemaValidateValue($expectedErrors, $schema, $value)
+    {
+        $this->assertEquals(
+            $expectedErrors,
+            SchemaValidationError::getErrorMessages($schema->validateRow(["name" => $value]))
+        );
+    }
+
+    protected function assertMissingValues($partialDescriptor, $missingValues)
+    {
+        $descriptor = (object)["name" => "name"];
+        foreach ($partialDescriptor as $k=>$v) {
+            $descriptor->{$k} = $v;
+        }
+        $schema = new Schema((object)[
+            "fields" => [$descriptor],
+            "missingValues" => $missingValues
+        ]);
+        foreach ($missingValues as $val) {
+            $this->assertEquals(["name" => null], $schema->castRow(["name" => $val]));
+        }
+    }
+}

--- a/tests/fixtures/data_infer.csv
+++ b/tests/fixtures/data_infer.csv
@@ -1,0 +1,5 @@
+id,age,name
+1,39,Paul
+2,23,Jimmy
+3,36,Jane
+4,28,Judy

--- a/tests/fixtures/data_infer_row_limit.csv
+++ b/tests/fixtures/data_infer_row_limit.csv
@@ -1,0 +1,12 @@
+id,age,name
+1,39,Paul
+2,23,Jimmy
+3,36,Jane
+4,28,Judy
+qwerty,nineteen,Rose
+werty,nineteen,Red
+erty,nineteen,Rotem
+rty,nineteen,Ruth
+ty,nineteen,Amber
+y,nineteen,Angel
+_,nineteen,Angie

--- a/tests/fixtures/data_infer_utf8.csv
+++ b/tests/fixtures/data_infer_utf8.csv
@@ -1,0 +1,6 @@
+id,age,name
+1,39,Paul
+2,23,Jimmy
+3,36,Jane
+4,28,Judy
+5,37,Iñtërnâtiônàlizætiøn

--- a/tests/fixtures/schema_invalid_multiple_errors.json
+++ b/tests/fixtures/schema_invalid_multiple_errors.json
@@ -1,0 +1,24 @@
+{
+    "fields": [
+        {
+            "name": "id",
+            "title": "Identifier",
+            "type": "magical_unicorn"
+        },
+        {
+            "name": "title",
+            "title": "Title",
+            "type": "string"
+        }
+    ],
+    "primaryKey": "identifier",
+    "foreignKeys": [
+        {
+            "fields": ["id", "notafield"],
+            "reference": {
+                "datapackage": "http://data.okfn.org/data/mydatapackage/",
+                "fields": "no" 
+            }
+        }
+    ]
+}

--- a/tests/fixtures/schema_valid_full.json
+++ b/tests/fixtures/schema_valid_full.json
@@ -1,0 +1,110 @@
+{
+    "fields": [
+        {
+            "name": "first_name",
+            "title": "First Name",
+            "type": "string",
+            "description": "The first name of the person"
+        },
+        {
+            "name": "last_name",
+            "title": "Last Name",
+            "type": "string",
+            "description": "The last name of the person"
+        },
+        {
+            "name": "gender",
+            "title": "Gender",
+            "type": "string",
+            "description": "The gender of the person."
+        },
+        {
+            "name": "age",
+            "title": "Age",
+            "type": "integer",
+            "description": "The age of this person."
+        },
+        {
+            "name": "period_employed",
+            "title": "Period Employed",
+            "type": "number",
+            "description": "The period of employment, in years (eg: 2.6 Y)."
+        },
+        {
+            "name": "employment_start",
+            "title": "Employment Start",
+            "type": "date",
+            "description": "The date this person started employment."
+        },
+        {
+            "name": "daily_start",
+            "title": "Daily Start",
+            "type": "time",
+            "description": "Usual start time for this person."
+        },
+        {
+            "name": "daily_end",
+            "title": "Daily End",
+            "type": "time",
+            "description": "Usual end time for this person."
+        },
+        {
+            "name": "is_management",
+            "title": "Is Management",
+            "type": "boolean",
+            "description": "Is this person part of upper management."
+        },
+        {
+            "name": "photo",
+            "title": "Photo",
+            "type": "string",
+            "format": "binary",
+            "description": "A photo of this person."
+        },
+        {
+            "name": "interests",
+            "title": "Interests",
+            "type": "array",
+            "description": "Declared interests of this person (work-related)."
+        },
+        {
+            "name": "home_location",
+            "title": "Home Location",
+            "type": "geopoint",
+            "description": "A geopoint for this person's home address."
+        },
+        {
+            "name": "position_title",
+            "title": "Position Title",
+            "type": "string",
+            "description": "This person's position in the company."
+        },
+        {
+            "name": "extra",
+            "title": "Extra",
+            "type": "object",
+            "description": "Extra information about this person."
+        },
+        {
+            "name": "notes",
+            "title": "Notes",
+            "type": "any",
+            "description": "Add any relevant notes for HR."
+        }
+    ],
+    "primaryKey": [
+        "first_name",
+        "last_name",
+        "period_employed",
+        "home_location"
+    ],
+    "foreignKeys": [
+        {
+            "fields": ["position_title"],
+            "reference": {
+                "resource": "positions",
+                "fields": ["name"]
+            }
+        }
+    ]
+}

--- a/tests/fixtures/schema_valid_simple.json
+++ b/tests/fixtures/schema_valid_simple.json
@@ -1,0 +1,14 @@
+{
+    "fields": [
+        {
+            "name": "id",
+            "title": "Identifier",
+            "type": "integer"
+        },
+        {
+            "name": "title",
+            "title": "Title",
+            "type": "string"
+        }
+    ]
+}


### PR DESCRIPTION
* copied tests from [tableschema-py](https://github.com/frictionlessdata/tableschema-py) (@[da855b73e068ed659681519d514b5b850f3488ad](https://github.com/frictionlessdata/tableschema-py/commit/da855b73e068ed659681519d514b5b850f3488ad))
  * tests/test_field.py -> tests/FieldTest.php
  * tests/test_schema.py -> tests/SchemaTest.php
* implemented related missing functionality
  * added functionality to Field object, including checking constraints and getter methods for default values.
  * added functionality to Schema object:
    * fullDescriptor method - returns decriptor with all defaults filled-in
    * save method - writes the fullDescriptor to a json file
    * getter methods for `missingValues`, `primaryKey`, `foreignKeys`
    * reuse of Field objects
  * major refactoring, finalized the interfaces
  * schema validator - hacked to allow empty reference resource (see #19)
  * Table object - added checking of unique values when iterating over the data