### PR TITLE
add field types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4",
-        "justinrainbow/json-schema": "^5.2"
+        "justinrainbow/json-schema": "^5.2",
+        "nesbot/carbon": "^1.22"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": ">=5.4",
         "justinrainbow/json-schema": "^5.2",
-        "nesbot/carbon": "^1.22"
+        "nesbot/carbon": "^1.22",
+        "jmikola/geojson": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35",

--- a/src/Fields/AnyField.php
+++ b/src/Fields/AnyField.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+class AnyField extends BaseField
+{
+    public static function type()
+    {
+        return 'any';
+    }
+
+    protected function validateCastValue($val)
+    {
+        return $val;
+    }
+
+    protected function isEmptyValue($val)
+    {
+        return false;
+    }
+}

--- a/src/Fields/ArrayField.php
+++ b/src/Fields/ArrayField.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+class ArrayField extends BaseField
+{
+    protected function validateCastValue($val)
+    {
+        if (is_array($val)) {
+            return $val;
+        } elseif (is_string($val)) {
+            try {
+                $val = json_decode($val);
+            } catch (\Exception $e) {
+                throw $this->getValidationException($e->getMessage(), $val);
+            }
+            if (!is_array($val)) {
+                throw $this->getValidationException("json string must decode to array", $val);
+            } else {
+                return $val;
+            }
+        } else {
+            throw $this->getValidationException("must be array or string", $val);
+        }
+    }
+
+    public static function type()
+    {
+        return 'array';
+    }
+}

--- a/src/Fields/ArrayField.php
+++ b/src/Fields/ArrayField.php
@@ -15,12 +15,12 @@ class ArrayField extends BaseField
                 throw $this->getValidationException($e->getMessage(), $val);
             }
             if (!is_array($val)) {
-                throw $this->getValidationException("json string must decode to array", $val);
+                throw $this->getValidationException('json string must decode to array', $val);
             } else {
                 return $val;
             }
         } else {
-            throw $this->getValidationException("must be array or string", $val);
+            throw $this->getValidationException('must be array or string', $val);
         }
     }
 

--- a/src/Fields/BaseField.php
+++ b/src/Fields/BaseField.php
@@ -180,9 +180,9 @@ abstract class BaseField
     {
         return new FieldValidationException([
             new SchemaValidationError(SchemaValidationError::FIELD_VALIDATION, [
-                'field' => isset($this->descriptor()->name) ? $this->name() : "unknown",
+                'field' => isset($this->descriptor()->name) ? $this->name() : 'unknown',
                 'value' => $val,
-                'error' => is_null($errorMsg) ? "invalid value" : $errorMsg,
+                'error' => is_null($errorMsg) ? 'invalid value' : $errorMsg,
             ]),
         ]);
     }

--- a/src/Fields/BaseField.php
+++ b/src/Fields/BaseField.php
@@ -141,6 +141,7 @@ abstract class BaseField
                     throw new FieldValidationException($validationErrors);
                 }
             }
+
             return $val;
         }
     }
@@ -300,7 +301,7 @@ abstract class BaseField
         } elseif (is_object($val)) {
             return count($val) >= $minLength;
         } else {
-            throw $this->getValidationException("invalid value for minLength constraint", $val);
+            throw $this->getValidationException('invalid value for minLength constraint', $val);
         }
     }
 
@@ -313,7 +314,7 @@ abstract class BaseField
         } elseif (is_object($val)) {
             return count($val) <= $maxLength;
         } else {
-            throw $this->getValidationException("invalid value for maxLength constraint", $val);
+            throw $this->getValidationException('invalid value for maxLength constraint', $val);
         }
     }
 

--- a/src/Fields/BaseField.php
+++ b/src/Fields/BaseField.php
@@ -176,13 +176,13 @@ abstract class BaseField
     protected $descriptor;
     protected $constraintsDisabled = false;
 
-    protected function getValidationException($errorMsg, $val = null)
+    protected function getValidationException($errorMsg = null, $val = null)
     {
         return new FieldValidationException([
             new SchemaValidationError(SchemaValidationError::FIELD_VALIDATION, [
-                'field' => $this->name(),
+                'field' => isset($this->descriptor()->name) ? $this->name() : "unknown",
                 'value' => $val,
-                'error' => $errorMsg,
+                'error' => is_null($errorMsg) ? "invalid value" : $errorMsg,
             ]),
         ]);
     }

--- a/src/Fields/BooleanField.php
+++ b/src/Fields/BooleanField.php
@@ -9,12 +9,12 @@ class BooleanField extends BaseField
         if (isset($this->descriptor()->trueValues)) {
             $trueValues = $this->descriptor()->trueValues;
         } else {
-            $trueValues = [ "true", "True", "TRUE", "1" ];
+            $trueValues = ['true', 'True', 'TRUE', '1'];
         }
         if (isset($this->descriptor()->falseValues)) {
             $falseValues = $this->descriptor()->falseValues;
         } else {
-            $falseValues = [ "false", "False", "FALSE", "0" ];
+            $falseValues = ['false', 'False', 'FALSE', '0'];
         }
         if (is_bool($val)) {
             return $val;
@@ -24,10 +24,10 @@ class BooleanField extends BaseField
             } elseif (in_array($val, $falseValues)) {
                 return false;
             } else {
-                throw $this->getValidationException("invalid bool value", $val);
+                throw $this->getValidationException('invalid bool value', $val);
             }
         } else {
-            throw $this->getValidationException("value must be a bool or string", $val);
+            throw $this->getValidationException('value must be a bool or string', $val);
         }
     }
 

--- a/src/Fields/BooleanField.php
+++ b/src/Fields/BooleanField.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+class BooleanField extends BaseField
+{
+    protected function validateCastValue($val)
+    {
+        if (isset($this->descriptor()->trueValues)) {
+            $trueValues = $this->descriptor()->trueValues;
+        } else {
+            $trueValues = [ "true", "True", "TRUE", "1" ];
+        }
+        if (isset($this->descriptor()->falseValues)) {
+            $falseValues = $this->descriptor()->falseValues;
+        } else {
+            $falseValues = [ "false", "False", "FALSE", "0" ];
+        }
+        if (is_bool($val)) {
+            return $val;
+        } elseif (is_string($val)) {
+            if (in_array($val, $trueValues)) {
+                return true;
+            } elseif (in_array($val, $falseValues)) {
+                return false;
+            } else {
+                throw $this->getValidationException("invalid bool value", $val);
+            }
+        } else {
+            throw $this->getValidationException("value must be a bool or string", $val);
+        }
+    }
+
+    public static function type()
+    {
+        return 'boolean';
+    }
+}

--- a/src/Fields/DateField.php
+++ b/src/Fields/DateField.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+use Carbon\Carbon;
+
+class DateField extends BaseField
+{
+    protected function validateCastValue($val)
+    {
+        switch ($this->format()) {
+            case "default":
+                try {
+                    list($year, $month, $day) = explode("-", $val);
+                    return Carbon::create($year, $month, $day, 0, 0, 0, "UTC");
+                } catch (\Exception $e) {
+                    throw $this->getValidationException($e->getMessage(), $val);
+                }
+            case "any":
+                try {
+                    $date = new Carbon($val);
+                    $date->setTime(0, 0, 0);
+                    return $date;
+                } catch (\Exception $e) {
+                    throw $this->getValidationException($e->getMessage(), $val);
+                }
+            default:
+                $date = strptime($val, $this->format());
+                if ($date === false || $date['unparsed'] != '') {
+                    throw $this->getValidationException("couldn't parse date/time according to given strptime format '{$this->format()}''", $val);
+                } else {
+                    return Carbon::create(
+                        (int)$date["tm_year"]+1900, (int)$date["tm_mon"]+1, (int)$date["tm_mday"],
+                        0, 0, 0
+                    );
+                }
+        }
+    }
+
+    public static function type()
+    {
+        return 'date';
+    }
+}

--- a/src/Fields/DateField.php
+++ b/src/Fields/DateField.php
@@ -9,17 +9,19 @@ class DateField extends BaseField
     protected function validateCastValue($val)
     {
         switch ($this->format()) {
-            case "default":
+            case 'default':
                 try {
-                    list($year, $month, $day) = explode("-", $val);
-                    return Carbon::create($year, $month, $day, 0, 0, 0, "UTC");
+                    list($year, $month, $day) = explode('-', $val);
+
+                    return Carbon::create($year, $month, $day, 0, 0, 0, 'UTC');
                 } catch (\Exception $e) {
                     throw $this->getValidationException($e->getMessage(), $val);
                 }
-            case "any":
+            case 'any':
                 try {
                     $date = new Carbon($val);
                     $date->setTime(0, 0, 0);
+
                     return $date;
                 } catch (\Exception $e) {
                     throw $this->getValidationException($e->getMessage(), $val);
@@ -30,7 +32,7 @@ class DateField extends BaseField
                     throw $this->getValidationException("couldn't parse date/time according to given strptime format '{$this->format()}''", $val);
                 } else {
                     return Carbon::create(
-                        (int)$date["tm_year"]+1900, (int)$date["tm_mon"]+1, (int)$date["tm_mday"],
+                        (int) $date['tm_year'] + 1900, (int) $date['tm_mon'] + 1, (int) $date['tm_mday'],
                         0, 0, 0
                     );
                 }

--- a/src/Fields/DatetimeField.php
+++ b/src/Fields/DatetimeField.php
@@ -10,21 +10,22 @@ class DatetimeField extends BaseField
     {
         $val = trim($val);
         switch ($this->format()) {
-            case "default":
-                if (substr($val, -1) != "Z") {
-                    throw $this->getValidationException("must have trailing Z", $val);
+            case 'default':
+                if (substr($val, -1) != 'Z') {
+                    throw $this->getValidationException('must have trailing Z', $val);
                 } else {
                     try {
-                        $val = rtrim($val, "Z");
-                        $val = explode("T", $val);
-                        list($year, $month, $day) = explode("-", $val[0]);
-                        list($hour, $minute, $second) = explode(":", $val[1]);
-                        return Carbon::create($year, $month, $day, $hour, $minute, $second, "UTC");
+                        $val = rtrim($val, 'Z');
+                        $val = explode('T', $val);
+                        list($year, $month, $day) = explode('-', $val[0]);
+                        list($hour, $minute, $second) = explode(':', $val[1]);
+
+                        return Carbon::create($year, $month, $day, $hour, $minute, $second, 'UTC');
                     } catch (\Exception $e) {
                         throw $this->getValidationException($e->getMessage(), $val);
                     }
                 }
-            case "any":
+            case 'any':
                 try {
                     return new Carbon($val);
                 } catch (\Exception $e) {
@@ -36,8 +37,8 @@ class DatetimeField extends BaseField
                     throw $this->getValidationException("couldn't parse date/time according to given strptime format '{$this->format()}''", $val);
                 } else {
                     return Carbon::create(
-                        (int)$date["tm_year"]+1900, (int)$date["tm_mon"]+1, (int)$date["tm_mday"],
-                        (int)$date["tm_hour"], (int)$date["tm_min"], (int)$date["tm_sec"]
+                        (int) $date['tm_year'] + 1900, (int) $date['tm_mon'] + 1, (int) $date['tm_mday'],
+                        (int) $date['tm_hour'], (int) $date['tm_min'], (int) $date['tm_sec']
                     );
                 }
         }

--- a/src/Fields/DatetimeField.php
+++ b/src/Fields/DatetimeField.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+use Carbon\Carbon;
+
+class DatetimeField extends BaseField
+{
+    protected function validateCastValue($val)
+    {
+        $val = trim($val);
+        switch ($this->format()) {
+            case "default":
+                if (substr($val, -1) != "Z") {
+                    throw $this->getValidationException("must have trailing Z", $val);
+                } else {
+                    try {
+                        $val = rtrim($val, "Z");
+                        $val = explode("T", $val);
+                        list($year, $month, $day) = explode("-", $val[0]);
+                        list($hour, $minute, $second) = explode(":", $val[1]);
+                        return Carbon::create($year, $month, $day, $hour, $minute, $second, "UTC");
+                    } catch (\Exception $e) {
+                        throw $this->getValidationException($e->getMessage(), $val);
+                    }
+                }
+            case "any":
+                try {
+                    return new Carbon($val);
+                } catch (\Exception $e) {
+                    throw $this->getValidationException($e->getMessage(), $val);
+                }
+            default:
+                $date = strptime($val, $this->format());
+                if ($date === false || $date['unparsed'] != '') {
+                    throw $this->getValidationException("couldn't parse date/time according to given strptime format '{$this->format()}''", $val);
+                } else {
+                    return Carbon::create(
+                        (int)$date["tm_year"]+1900, (int)$date["tm_mon"]+1, (int)$date["tm_mday"],
+                        (int)$date["tm_hour"], (int)$date["tm_min"], (int)$date["tm_sec"]
+                    );
+                }
+        }
+    }
+
+    public static function type()
+    {
+        return 'datetime';
+    }
+}

--- a/src/Fields/DurationField.php
+++ b/src/Fields/DurationField.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+use Carbon\Carbon;
+use Carbon\CarbonInterval;
+
+class DurationField extends BaseField
+{
+    protected function validateCastValue($val)
+    {
+        if (!is_string($val)) {
+            throw $this->getValidationException("must be string", $val);
+        } else {
+            $val = trim($val);
+            try {
+                // we create a dateInterval first, because it's more restrictive
+                return CarbonInterval::instance(new \DateInterval($val));
+            } catch (\Exception $e) {
+                throw $this->getValidationException($e->getMessage(), $val);
+            }
+        }
+    }
+
+    public static function type()
+    {
+        return 'duration';
+    }
+
+    protected function checkAllowedValues($allowedValues, $val)
+    {
+        foreach ($allowedValues as $allowedValue) {
+            if (
+                $val->years == $allowedValue->years
+                && $val->months == $allowedValue->months
+                && $val->days == $allowedValue->days
+                && $val->hours == $allowedValue->hours
+                && $val->minutes == $allowedValue->minutes
+                && $val->seconds == $allowedValue->seconds
+            ) return true;
+        }
+        return false;
+    }
+}

--- a/src/Fields/DurationField.php
+++ b/src/Fields/DurationField.php
@@ -2,7 +2,6 @@
 
 namespace frictionlessdata\tableschema\Fields;
 
-use Carbon\Carbon;
 use Carbon\CarbonInterval;
 
 class DurationField extends BaseField
@@ -10,7 +9,7 @@ class DurationField extends BaseField
     protected function validateCastValue($val)
     {
         if (!is_string($val)) {
-            throw $this->getValidationException("must be string", $val);
+            throw $this->getValidationException('must be string', $val);
         } else {
             $val = trim($val);
             try {
@@ -37,8 +36,11 @@ class DurationField extends BaseField
                 && $val->hours == $allowedValue->hours
                 && $val->minutes == $allowedValue->minutes
                 && $val->seconds == $allowedValue->seconds
-            ) return true;
+            ) {
+                return true;
+            }
         }
+
         return false;
     }
 }

--- a/src/Fields/FieldsFactory.php
+++ b/src/Fields/FieldsFactory.php
@@ -8,7 +8,7 @@ use frictionlessdata\tableschema\SchemaValidationError;
 class FieldsFactory
 {
     /**
-     * list of all the available field classes
+     * list of all the available field classes.
      *
      * this list is used when inferring field type from a value
      * infer works by trying to case the value to the field, in the fieldClasses order

--- a/src/Fields/FieldsFactory.php
+++ b/src/Fields/FieldsFactory.php
@@ -23,6 +23,15 @@ class FieldsFactory
         '\\frictionlessdata\\tableschema\\Fields\\YearMonthField',
         '\\frictionlessdata\\tableschema\\Fields\\YearField',
         '\\frictionlessdata\\tableschema\\Fields\\TimeField',
+        '\\frictionlessdata\\tableschema\\Fields\\ObjectField',
+        '\\frictionlessdata\\tableschema\\Fields\\GeopointField',
+        '\\frictionlessdata\\tableschema\\Fields\\GeojsonField',
+        '\\frictionlessdata\\tableschema\\Fields\\DurationField',
+        '\\frictionlessdata\\tableschema\\Fields\\DatetimeField',
+        '\\frictionlessdata\\tableschema\\Fields\\DateField',
+        '\\frictionlessdata\\tableschema\\Fields\\BooleanField',
+        '\\frictionlessdata\\tableschema\\Fields\\ArrayField',
+        '\\frictionlessdata\\tableschema\\Fields\\AnyField',
     ];
 
     /**

--- a/src/Fields/FieldsFactory.php
+++ b/src/Fields/FieldsFactory.php
@@ -9,12 +9,20 @@ class FieldsFactory
 {
     /**
      * list of all the available field classes
-     * ordered in infer order - the most strict field first.
+     *
+     * this list is used when inferring field type from a value
+     * infer works by trying to case the value to the field, in the fieldClasses order
+     * first field that doesn't raise exception on infer wins
      */
     public static $fieldClasses = [
         '\\frictionlessdata\\tableschema\\Fields\\IntegerField',
         '\\frictionlessdata\\tableschema\\Fields\\NumberField',
         '\\frictionlessdata\\tableschema\\Fields\\StringField',
+
+        // these fields will not be inferred - StringField will catch all values before it reaches these
+        '\\frictionlessdata\\tableschema\\Fields\\YearMonthField',
+        '\\frictionlessdata\\tableschema\\Fields\\YearField',
+        '\\frictionlessdata\\tableschema\\Fields\\TimeField',
     ];
 
     /**

--- a/src/Fields/GeojsonField.php
+++ b/src/Fields/GeojsonField.php
@@ -14,9 +14,9 @@ class GeojsonField extends BaseField
             }
         }
         if (!is_object($val)) {
-            throw $this->getValidationException("must be an object", $val);
+            throw $this->getValidationException('must be an object', $val);
         }
-        if ($this->format() == "default") {
+        if ($this->format() == 'default') {
             try {
                 // this validates the geojson
                 \GeoJson\GeoJson::jsonUnserialize($val);
@@ -24,6 +24,7 @@ class GeojsonField extends BaseField
                 throw $this->getValidationException($e->getMessage(), $val);
             }
         }
+
         return $val;
     }
 

--- a/src/Fields/GeojsonField.php
+++ b/src/Fields/GeojsonField.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+class GeojsonField extends BaseField
+{
+    protected function validateCastValue($val)
+    {
+        if (is_string($val)) {
+            try {
+                $val = json_decode($val);
+            } catch (\Exception $e) {
+                throw $this->getValidationException($e->getMessage(), $val);
+            }
+        }
+        if (!is_object($val)) {
+            throw $this->getValidationException("must be an object", $val);
+        }
+        if ($this->format() == "default") {
+            try {
+                // this validates the geojson
+                \GeoJson\GeoJson::jsonUnserialize($val);
+            } catch (\Exception $e) {
+                throw $this->getValidationException($e->getMessage(), $val);
+            }
+        }
+        return $val;
+    }
+
+    public static function type()
+    {
+        return 'geojson';
+    }
+}

--- a/src/Fields/GeopointField.php
+++ b/src/Fields/GeopointField.php
@@ -6,36 +6,36 @@ class GeopointField extends BaseField
 {
     protected function validateCastValue($val)
     {
-        if (in_array($this->format(), ["array", "object"]) && is_string($val)) {
+        if (in_array($this->format(), ['array', 'object']) && is_string($val)) {
             try {
                 $val = json_decode($val);
             } catch (\Exception $e) {
                 throw $this->getValidationException($e->getMessage(), $val);
             }
-        };
+        }
         switch ($this->format()) {
-            case "default":
+            case 'default':
                 if (!is_string($val)) {
-                    throw $this->getValidationException("value must be a string", $val);
+                    throw $this->getValidationException('value must be a string', $val);
                 } else {
-                    return $this->getNativeGeopoint(explode(",", $val));
+                    return $this->getNativeGeopoint(explode(',', $val));
                 }
-            case "array":
+            case 'array':
                 if (!is_array($val)) {
-                    throw $this->getValidationException("value must be an array", $val);
+                    throw $this->getValidationException('value must be an array', $val);
                 } else {
                     return $this->getNativeGeopoint($val);
                 }
-            case "object":
+            case 'object':
                 if (!is_object($val)) {
-                    throw $this->getValidationException("value must be an object", $val);
+                    throw $this->getValidationException('value must be an object', $val);
                 } elseif (!isset($val->lat) || !isset($val->lon)) {
-                    throw $this->getValidationException("object must contain lon and lat attributes", $val);
+                    throw $this->getValidationException('object must contain lon and lat attributes', $val);
                 } else {
                     return $this->getNativeGeopoint([$val->lon, $val->lat]);
                 }
             default:
-                throw $this->getValidationException("invalid format", $val);
+                throw $this->getValidationException('invalid format', $val);
         }
     }
 
@@ -44,18 +44,19 @@ class GeopointField extends BaseField
         return 'geopoint';
     }
 
-    protected function getNativeGeopoint($arr) {
+    protected function getNativeGeopoint($arr)
+    {
         if (count($arr) != 2) {
-            throw $this->getValidationException("lon,lat array must contain only lon,lat", json_encode($arr));
+            throw $this->getValidationException('lon,lat array must contain only lon,lat', json_encode($arr));
         } else {
             list($lon, $lat) = $arr;
-            $lon = (int)$lon;
-            $lat = (int)$lat;
+            $lon = (int) $lon;
+            $lat = (int) $lat;
             if (
                 $lon > 180 || $lon < -180
                 || $lat > 90 or $lat < -90
             ) {
-                throw $this->getValidationException("invalid lon,lat values", json_encode($arr));
+                throw $this->getValidationException('invalid lon,lat values', json_encode($arr));
             } else {
                 return [$lon, $lat];
             }

--- a/src/Fields/GeopointField.php
+++ b/src/Fields/GeopointField.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+class GeopointField extends BaseField
+{
+    protected function validateCastValue($val)
+    {
+        if (in_array($this->format(), ["array", "object"]) && is_string($val)) {
+            try {
+                $val = json_decode($val);
+            } catch (\Exception $e) {
+                throw $this->getValidationException($e->getMessage(), $val);
+            }
+        };
+        switch ($this->format()) {
+            case "default":
+                if (!is_string($val)) {
+                    throw $this->getValidationException("value must be a string", $val);
+                } else {
+                    return $this->getNativeGeopoint(explode(",", $val));
+                }
+            case "array":
+                if (!is_array($val)) {
+                    throw $this->getValidationException("value must be an array", $val);
+                } else {
+                    return $this->getNativeGeopoint($val);
+                }
+            case "object":
+                if (!is_object($val)) {
+                    throw $this->getValidationException("value must be an object", $val);
+                } elseif (!isset($val->lat) || !isset($val->lon)) {
+                    throw $this->getValidationException("object must contain lon and lat attributes", $val);
+                } else {
+                    return $this->getNativeGeopoint([$val->lon, $val->lat]);
+                }
+            default:
+                throw $this->getValidationException("invalid format", $val);
+        }
+    }
+
+    public static function type()
+    {
+        return 'geopoint';
+    }
+
+    protected function getNativeGeopoint($arr) {
+        if (count($arr) != 2) {
+            throw $this->getValidationException("lon,lat array must contain only lon,lat", json_encode($arr));
+        } else {
+            list($lon, $lat) = $arr;
+            $lon = (int)$lon;
+            $lat = (int)$lat;
+            if (
+                $lon > 180 || $lon < -180
+                || $lat > 90 or $lat < -90
+            ) {
+                throw $this->getValidationException("invalid lon,lat values", json_encode($arr));
+            } else {
+                return [$lon, $lat];
+            }
+        }
+    }
+}

--- a/src/Fields/IntegerField.php
+++ b/src/Fields/IntegerField.php
@@ -11,9 +11,8 @@ class IntegerField extends BaseField
      *
      * @throws \frictionlessdata\tableschema\Exceptions\FieldValidationException;
      */
-    public function validateCastValue($val)
+    protected function validateCastValue($val)
     {
-        $val = parent::validateCastValue($val);
         if (!is_numeric($val)) {
             throw $this->getValidationException('value must be numeric', $val);
         } else {
@@ -29,10 +28,5 @@ class IntegerField extends BaseField
     public static function type()
     {
         return 'integer';
-    }
-
-    protected function isEmptyValue($val)
-    {
-        return !is_numeric($val) && empty($val);
     }
 }

--- a/src/Fields/NumberField.php
+++ b/src/Fields/NumberField.php
@@ -15,20 +15,20 @@ class NumberField extends BaseField
     {
         $isPercent = false;
         if (is_string($val)) {
-            if (substr($val, -1) == "%") {
-                $val = rtrim($val, "%");
+            if (substr($val, -1) == '%') {
+                $val = rtrim($val, '%');
                 $isPercent = true;
             }
             if (isset($this->descriptor()->groupChar)) {
-                $val = str_replace($this->descriptor()->groupChar, "", $val);
+                $val = str_replace($this->descriptor()->groupChar, '', $val);
             }
-            if (isset($this->descriptor()->decimalChar) && $this->descriptor()->decimalChar != ".") {
-                $val = str_replace($this->descriptor()->decimalChar, ".", $val);
+            if (isset($this->descriptor()->decimalChar) && $this->descriptor()->decimalChar != '.') {
+                $val = str_replace($this->descriptor()->decimalChar, '.', $val);
             }
             if (isset($this->descriptor()->currency) && $this->descriptor()->currency) {
-                $newval = "";
+                $newval = '';
                 foreach (str_split($val) as $chr) {
-                    if (is_numeric($chr) || $chr == "." || $chr == "+" || $chr == "-") {
+                    if (is_numeric($chr) || $chr == '.' || $chr == '+' || $chr == '-') {
                         $newval .= $chr;
                     }
                 }
@@ -42,6 +42,7 @@ class NumberField extends BaseField
             if ($isPercent) {
                 $val = $val / 100;
             }
+
             return $val;
         }
     }

--- a/src/Fields/NumberField.php
+++ b/src/Fields/NumberField.php
@@ -11,23 +11,43 @@ class NumberField extends BaseField
      *
      * @throws \frictionlessdata\tableschema\Exceptions\FieldValidationException;
      */
-    public function validateCastValue($val)
+    protected function validateCastValue($val)
     {
-        $val = parent::validateCastValue($val);
+        $isPercent = false;
+        if (is_string($val)) {
+            if (substr($val, -1) == "%") {
+                $val = rtrim($val, "%");
+                $isPercent = true;
+            }
+            if (isset($this->descriptor()->groupChar)) {
+                $val = str_replace($this->descriptor()->groupChar, "", $val);
+            }
+            if (isset($this->descriptor()->decimalChar) && $this->descriptor()->decimalChar != ".") {
+                $val = str_replace($this->descriptor()->decimalChar, ".", $val);
+            }
+            if (isset($this->descriptor()->currency) && $this->descriptor()->currency) {
+                $newval = "";
+                foreach (str_split($val) as $chr) {
+                    if (is_numeric($chr) || $chr == "." || $chr == "+" || $chr == "-") {
+                        $newval .= $chr;
+                    }
+                }
+                $val = $newval;
+            }
+        }
         if (!is_numeric($val)) {
             throw $this->getValidationException('value must be numeric', $val);
         } else {
-            return (float) $val;
+            $val = (float) $val;
+            if ($isPercent) {
+                $val = $val / 100;
+            }
+            return $val;
         }
     }
 
     public static function type()
     {
         return 'number';
-    }
-
-    protected function isEmptyValue($val)
-    {
-        return !is_numeric($val) && empty($val);
     }
 }

--- a/src/Fields/ObjectField.php
+++ b/src/Fields/ObjectField.php
@@ -4,7 +4,7 @@ namespace frictionlessdata\tableschema\Fields;
 
 /**
  * Class ObjectField
- * casts to php object
+ * casts to php object.
  */
 class ObjectField extends BaseField
 {

--- a/src/Fields/ObjectField.php
+++ b/src/Fields/ObjectField.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+/**
+ * Class ObjectField
+ * casts to php object
+ */
+class ObjectField extends BaseField
+{
+    protected function validateCastValue($val)
+    {
+        try {
+            if (is_string($val)) {
+                $object = json_decode($val);
+            } elseif (is_object($val)) {
+                $object = json_decode(json_encode($val));
+            } else {
+                $object = null;
+            }
+        } catch (\Exception $e) {
+            throw $this->getValidationException($e->getMessage(), $val);
+        }
+        if (is_object($object)) {
+            return $object;
+        } else {
+            throw $this->getValidationException(null, $val);
+        }
+    }
+
+    public static function type()
+    {
+        return 'object';
+    }
+}

--- a/src/Fields/StringField.php
+++ b/src/Fields/StringField.php
@@ -24,7 +24,7 @@ class StringField extends BaseField
     protected function validateCastValue($val)
     {
         try {
-            $val = (string)$val;
+            $val = (string) $val;
         } catch (\Exception $e) {
             $val = json_encode($val);
         }

--- a/src/Fields/StringField.php
+++ b/src/Fields/StringField.php
@@ -8,7 +8,7 @@ class StringField extends BaseField
     {
         parent::inferProperties($val, $lenient);
         if (!$lenient) {
-            if (strpos($val, '@') !== false) {
+            if (is_string($val) && strpos($val, '@') !== false) {
                 $this->descriptor->format = 'email';
             }
         }
@@ -24,11 +24,22 @@ class StringField extends BaseField
     public function validateCastValue($val)
     {
         $val = parent::validateCastValue($val);
-        if ($this->format() == 'email' && strpos($val, '@') === false) {
-            throw $this->getValidationException('value is not a valid email', $val);
-        } else {
-            return $val;
+        switch ($this->format()) {
+            case "email":
+                if (strpos($val, '@') === false)
+                    throw $this->getValidationException('value is not a valid email', $val);
+                break;
+            case "uri":
+                if (filter_var($val, FILTER_VALIDATE_URL) === false)
+                    throw $this->getValidationException(null, $val);
+                break;
+            case "binary":
+                $decoded = base64_decode($val, true);
+                if ($decoded === false)
+                    throw $this->getValidationException(null, $val);
+                break;
         }
+        return $val;
     }
 
     public static function type()

--- a/src/Fields/StringField.php
+++ b/src/Fields/StringField.php
@@ -21,9 +21,8 @@ class StringField extends BaseField
      *
      * @throws \frictionlessdata\tableschema\Exceptions\FieldValidationException;
      */
-    public function validateCastValue($val)
+    protected function validateCastValue($val)
     {
-        $val = parent::validateCastValue($val);
         try {
             $val = (string)$val;
         } catch (\Exception $e) {

--- a/src/Fields/StringField.php
+++ b/src/Fields/StringField.php
@@ -25,20 +25,24 @@ class StringField extends BaseField
     {
         $val = parent::validateCastValue($val);
         switch ($this->format()) {
-            case "email":
-                if (strpos($val, '@') === false)
+            case 'email':
+                if (strpos($val, '@') === false) {
                     throw $this->getValidationException('value is not a valid email', $val);
+                }
                 break;
-            case "uri":
-                if (filter_var($val, FILTER_VALIDATE_URL) === false)
+            case 'uri':
+                if (filter_var($val, FILTER_VALIDATE_URL) === false) {
                     throw $this->getValidationException(null, $val);
+                }
                 break;
-            case "binary":
+            case 'binary':
                 $decoded = base64_decode($val, true);
-                if ($decoded === false)
+                if ($decoded === false) {
                     throw $this->getValidationException(null, $val);
+                }
                 break;
         }
+
         return $val;
     }
 

--- a/src/Fields/StringField.php
+++ b/src/Fields/StringField.php
@@ -24,6 +24,11 @@ class StringField extends BaseField
     public function validateCastValue($val)
     {
         $val = parent::validateCastValue($val);
+        try {
+            $val = (string)$val;
+        } catch (\Exception $e) {
+            $val = json_encode($val);
+        }
         switch ($this->format()) {
             case 'email':
                 if (strpos($val, '@') === false) {

--- a/src/Fields/TimeField.php
+++ b/src/Fields/TimeField.php
@@ -10,9 +10,8 @@ use Carbon\Carbon;
  */
 class TimeField extends BaseField
 {
-    public function validateCastValue($val)
+    protected function validateCastValue($val)
     {
-        $val = trim(parent::validateCastValue($val));
         switch ($this->format()) {
             case 'default':
                 $time = explode(':', $val);
@@ -43,11 +42,6 @@ class TimeField extends BaseField
     public static function type()
     {
         return 'time';
-    }
-
-    protected function isEmptyValue($val)
-    {
-        return (parent::isEmptyValue($val) || trim($val) == "");
     }
 
     protected function getNativeTime($hour, $minute, $second)

--- a/src/Fields/TimeField.php
+++ b/src/Fields/TimeField.php
@@ -6,7 +6,7 @@ use Carbon\Carbon;
 
 /**
  * Class TimeField
- * casts to array [hour, minute, second]
+ * casts to array [hour, minute, second].
  */
 class TimeField extends BaseField
 {
@@ -19,6 +19,7 @@ class TimeField extends BaseField
                     throw $this->getValidationException(null, $val);
                 } else {
                     list($hour, $minute, $second) = $time;
+
                     return $this->getNativeTime($hour, $minute, $second);
                 }
                 break;
@@ -28,6 +29,7 @@ class TimeField extends BaseField
                 } catch (\Exception $e) {
                     throw $this->getValidationException($e->getMessage(), $val);
                 }
+
                 return $this->getNativeTime($dt->hour, $dt->minute, $dt->second);
             default:
                 $date = strptime($val, $this->format());
@@ -50,6 +52,7 @@ class TimeField extends BaseField
         foreach ($parts as &$part) {
             $part = (int) $part;
         }
+
         return $parts;
     }
 }

--- a/src/Fields/TimeField.php
+++ b/src/Fields/TimeField.php
@@ -8,8 +8,8 @@ class TimeField extends BaseField
     {
         $val = parent::validateCastValue($val);
         switch ($this->format()) {
-            case "default":
-                $time = explode(":", $val);
+            case 'default':
+                $time = explode(':', $val);
                 if (count($time) != 3) {
                     throw $this->getValidationException(null, $val);
                 } else {
@@ -17,17 +17,17 @@ class TimeField extends BaseField
                     $nativeTime = mktime($hour, $minute, $second);
                 }
                 break;
-            case "any":
+            case 'any':
                 $nativeTime = strtotime($val);
                 break;
             default:
                 $date = strptime($val, $this->format());
-                if ($date === false || $date["unparsed"] != "") {
+                if ($date === false || $date['unparsed'] != '') {
                     throw $this->getValidationException(null, $val);
                 } else {
-                    $nativeTime = mktime($date["tm_hour"], $date["tm_min"], $date["tm_sec"]);
+                    $nativeTime = mktime($date['tm_hour'], $date['tm_min'], $date['tm_sec']);
                 }
-        };
+        }
         if ($nativeTime === false) {
             throw $this->getValidationException(null, $val);
         } else {

--- a/src/Fields/TimeField.php
+++ b/src/Fields/TimeField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+class TimeField extends BaseField
+{
+    public function validateCastValue($val)
+    {
+        $val = parent::validateCastValue($val);
+        switch ($this->format()) {
+            case "default":
+                $time = explode(":", $val);
+                if (count($time) != 3) {
+                    throw $this->getValidationException(null, $val);
+                } else {
+                    list($hour, $minute, $second) = $time;
+                    $nativeTime = mktime($hour, $minute, $second);
+                }
+                break;
+            case "any":
+                $nativeTime = strtotime($val);
+                break;
+            default:
+                $date = strptime($val, $this->format());
+                if ($date === false || $date["unparsed"] != "") {
+                    throw $this->getValidationException(null, $val);
+                } else {
+                    $nativeTime = mktime($date["tm_hour"], $date["tm_min"], $date["tm_sec"]);
+                }
+        };
+        if ($nativeTime === false) {
+            throw $this->getValidationException(null, $val);
+        } else {
+            return $nativeTime;
+        }
+    }
+
+    public static function type()
+    {
+        return 'time';
+    }
+}

--- a/src/Fields/YearField.php
+++ b/src/Fields/YearField.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+class YearField extends BaseField
+{
+    public function validateCastValue($val)
+    {
+        $val = parent::validateCastValue($val);
+        if ($val == "") {
+            throw $this->getValidationException(null, $val);
+        } else {
+            $year = (int)$val;
+            if ((float)$val != (float)$year) {
+                throw $this->getValidationException(null, $val);
+            } else {
+                return $year;
+            }
+        }
+    }
+
+    public static function type()
+    {
+        return 'year';
+    }
+}

--- a/src/Fields/YearField.php
+++ b/src/Fields/YearField.php
@@ -8,9 +8,8 @@ namespace frictionlessdata\tableschema\Fields;
  */
 class YearField extends BaseField
 {
-    public function validateCastValue($val)
+    protected function validateCastValue($val)
     {
-        $val = parent::validateCastValue($val);
         $year = (int) $val;
         if ((float) $val != (float) $year) {
             throw $this->getValidationException(null, $val);
@@ -22,10 +21,5 @@ class YearField extends BaseField
     public static function type()
     {
         return 'year';
-    }
-
-    protected function isEmptyValue($val)
-    {
-        return (parent::isEmptyValue($val) || trim($val) == "");
     }
 }

--- a/src/Fields/YearField.php
+++ b/src/Fields/YearField.php
@@ -4,7 +4,7 @@ namespace frictionlessdata\tableschema\Fields;
 
 /**
  * Class YearField
- * casts to integer
+ * casts to integer.
  */
 class YearField extends BaseField
 {

--- a/src/Fields/YearField.php
+++ b/src/Fields/YearField.php
@@ -7,11 +7,11 @@ class YearField extends BaseField
     public function validateCastValue($val)
     {
         $val = parent::validateCastValue($val);
-        if ($val == "") {
+        if ($val == '') {
             throw $this->getValidationException(null, $val);
         } else {
-            $year = (int)$val;
-            if ((float)$val != (float)$year) {
+            $year = (int) $val;
+            if ((float) $val != (float) $year) {
                 throw $this->getValidationException(null, $val);
             } else {
                 return $year;

--- a/src/Fields/YearField.php
+++ b/src/Fields/YearField.php
@@ -2,25 +2,30 @@
 
 namespace frictionlessdata\tableschema\Fields;
 
+/**
+ * Class YearField
+ * casts to integer
+ */
 class YearField extends BaseField
 {
     public function validateCastValue($val)
     {
         $val = parent::validateCastValue($val);
-        if ($val == '') {
+        $year = (int) $val;
+        if ((float) $val != (float) $year) {
             throw $this->getValidationException(null, $val);
         } else {
-            $year = (int) $val;
-            if ((float) $val != (float) $year) {
-                throw $this->getValidationException(null, $val);
-            } else {
-                return $year;
-            }
+            return $year;
         }
     }
 
     public static function type()
     {
         return 'year';
+    }
+
+    protected function isEmptyValue($val)
+    {
+        return (parent::isEmptyValue($val) || trim($val) == "");
     }
 }

--- a/src/Fields/YearMonthField.php
+++ b/src/Fields/YearMonthField.php
@@ -8,17 +8,17 @@ class YearMonthField extends BaseField
     {
         $val = parent::validateCastValue($val);
         if (!is_array($val)) {
-            $val = explode("-", $val);
+            $val = explode('-', $val);
         }
         if (count($val) != 2) {
             throw $this->getValidationException(null, $val);
         } else {
             list($year, $month) = $val;
-            if ($year == "" || $month == "") {
+            if ($year == '' || $month == '') {
                 throw $this->getValidationException(null, $val);
             } else {
-                $year = (int)$year;
-                $month = (int)$month;
+                $year = (int) $year;
+                $month = (int) $month;
                 if ($month < 1 || $month > 12) {
                     throw $this->getValidationException(null, $val);
                 } else {

--- a/src/Fields/YearMonthField.php
+++ b/src/Fields/YearMonthField.php
@@ -8,9 +8,8 @@ namespace frictionlessdata\tableschema\Fields;
  */
 class YearMonthField extends BaseField
 {
-    public function validateCastValue($val)
+    protected function validateCastValue($val)
     {
-        $val = parent::validateCastValue($val);
         if (!is_array($val)) {
             $val = explode('-', $val);
         }
@@ -40,10 +39,5 @@ class YearMonthField extends BaseField
     protected function getNativeYearMonth($year, $month)
     {
         return [$year, $month];
-    }
-
-    protected function isEmptyValue($val)
-    {
-        return (parent::isEmptyValue($val) || (!is_array($val) && trim($val) == "") || (is_array($val) && empty($val)));
     }
 }

--- a/src/Fields/YearMonthField.php
+++ b/src/Fields/YearMonthField.php
@@ -4,7 +4,7 @@ namespace frictionlessdata\tableschema\Fields;
 
 /**
  * Class YearMonthField
- * casts to array [year, month]
+ * casts to array [year, month].
  */
 class YearMonthField extends BaseField
 {

--- a/src/Fields/YearMonthField.php
+++ b/src/Fields/YearMonthField.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace frictionlessdata\tableschema\Fields;
+
+class YearMonthField extends BaseField
+{
+    public function validateCastValue($val)
+    {
+        $val = parent::validateCastValue($val);
+        if (!is_array($val)) {
+            $val = explode("-", $val);
+        }
+        if (count($val) != 2) {
+            throw $this->getValidationException(null, $val);
+        } else {
+            list($year, $month) = $val;
+            if ($year == "" || $month == "") {
+                throw $this->getValidationException(null, $val);
+            } else {
+                $year = (int)$year;
+                $month = (int)$month;
+                if ($month < 1 || $month > 12) {
+                    throw $this->getValidationException(null, $val);
+                } else {
+                    return [$year, $month];
+                }
+            }
+        }
+    }
+
+    public static function type()
+    {
+        return 'yearmonth';
+    }
+}

--- a/src/Fields/YearMonthField.php
+++ b/src/Fields/YearMonthField.php
@@ -2,6 +2,10 @@
 
 namespace frictionlessdata\tableschema\Fields;
 
+/**
+ * Class YearMonthField
+ * casts to array [year, month]
+ */
 class YearMonthField extends BaseField
 {
     public function validateCastValue($val)
@@ -22,7 +26,7 @@ class YearMonthField extends BaseField
                 if ($month < 1 || $month > 12) {
                     throw $this->getValidationException(null, $val);
                 } else {
-                    return [$year, $month];
+                    return $this->getNativeYearMonth($year, $month);
                 }
             }
         }
@@ -31,5 +35,15 @@ class YearMonthField extends BaseField
     public static function type()
     {
         return 'yearmonth';
+    }
+
+    protected function getNativeYearMonth($year, $month)
+    {
+        return [$year, $month];
+    }
+
+    protected function isEmptyValue($val)
+    {
+        return (parent::isEmptyValue($val) || (!is_array($val) && trim($val) == "") || (is_array($val) && empty($val)));
     }
 }

--- a/src/SchemaValidationError.php
+++ b/src/SchemaValidationError.php
@@ -40,7 +40,7 @@ class SchemaValidationError
             case self::FIELD_VALIDATION:
                 $field = $this->extraDetails['field'];
                 $error = $this->extraDetails['error'];
-                $value = $this->extraDetails['value'];
+                $value = json_encode($this->extraDetails['value']);
 
                 return "{$field}: {$error} ({$value})";
             case self::ROW_FIELD_VALIDATION:

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -92,7 +92,7 @@ class FieldTest extends TestCase
             FieldsFactory::field($this->DESCRIPTOR_MAX)->castValue('');
             $this->fail();
         } catch (FieldValidationException $e) {
-            $this->assertEquals('id: field is required ()', $e->getMessage());
+            $this->assertEquals('id: field is required ("")', $e->getMessage());
         }
     }
 
@@ -123,8 +123,8 @@ class FieldTest extends TestCase
     public function testValidateValue()
     {
         $this->assertFieldValidateValue('', $this->DESCRIPTOR_MAX, '1');
-        $this->assertFieldValidateValue('id: value must be numeric (string)', $this->DESCRIPTOR_MAX, 'string');
-        $this->assertFieldValidateValue('id: field is required ()', $this->DESCRIPTOR_MAX, '');
+        $this->assertFieldValidateValue('id: value must be numeric ("string")', $this->DESCRIPTOR_MAX, 'string');
+        $this->assertFieldValidateValue('id: field is required ("")', $this->DESCRIPTOR_MAX, '');
     }
 
     public function testValidateValueDisableConstraints()
@@ -160,11 +160,11 @@ class FieldTest extends TestCase
         $this->assertSchemaValidateValue('', $schema, 'none');
         $this->assertSchemaValidateValue('', $schema, 'nil');
         $this->assertSchemaValidateValue('', $schema, 'nan');
-        $this->assertSchemaValidateValue('name: field is required ()', $schema, 'NA');
-        $this->assertSchemaValidateValue('name: field is required ()', $schema, 'N/A');
+        $this->assertSchemaValidateValue('name: field is required (null)', $schema, 'NA');
+        $this->assertSchemaValidateValue('name: field is required (null)', $schema, 'N/A');
         $this->assertSchemaValidateValue('', $schema, '-');
-        $this->assertSchemaValidateValue('name: field is required ()', $schema, '');
-        $this->assertSchemaValidateValue('name: field is required ()', $schema, null);
+        $this->assertSchemaValidateValue('name: field is required (null)', $schema, '');
+        $this->assertSchemaValidateValue('name: field is required (null)', $schema, null);
     }
 
     public function testValidateValuePattern()
@@ -176,7 +176,7 @@ class FieldTest extends TestCase
         ];
         $this->assertFieldValidateValue('', $descriptor, '3');
         $this->assertFieldValidateValue('', $descriptor, '321');
-        $this->assertFieldValidateValue('name: value does not match pattern (123)', $descriptor, '123');
+        $this->assertFieldValidateValue('name: value does not match pattern ("123")', $descriptor, '123');
     }
 
     public function testValidateValueUnique()
@@ -223,7 +223,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, '1');
         $this->assertFieldValidateValue('', $descriptor, 2);
         $this->assertFieldValidateValue('', $descriptor, '3');
-        $this->assertFieldValidateValue('name: value not in enum (4)', $descriptor, '4');
+        $this->assertFieldValidateValue('name: value not in enum ("4")', $descriptor, '4');
         $this->assertFieldValidateValue('name: value not in enum (4)', $descriptor, 4);
     }
 
@@ -238,7 +238,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, 2);
         $this->assertFieldValidateValue('', $descriptor, '1');
         $this->assertFieldValidateValue('', $descriptor, 1);
-        $this->assertFieldValidateValue('name: value is below minimum (0)', $descriptor, '0');
+        $this->assertFieldValidateValue('name: value is below minimum ("0")', $descriptor, '0');
         $this->assertFieldValidateValue('name: value is below minimum (0)', $descriptor, 0);
     }
 
@@ -253,7 +253,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, 0);
         $this->assertFieldValidateValue('', $descriptor, '1');
         $this->assertFieldValidateValue('', $descriptor, 1);
-        $this->assertFieldValidateValue('name: value is above maximum (2)', $descriptor, '2');
+        $this->assertFieldValidateValue('name: value is above maximum ("2")', $descriptor, '2');
         $this->assertFieldValidateValue('name: value is above maximum (2)', $descriptor, 2);
     }
 
@@ -268,7 +268,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, 'aaaa');
         // null value passes (because field is not required)
         $this->assertFieldValidateValue('', $descriptor, null);
-        $this->assertFieldValidateValue('name: value is below minimum length (a)', $descriptor, 'a');
+        $this->assertFieldValidateValue('name: value is below minimum length ("a")', $descriptor, 'a');
     }
 
     public function testValidateValueMaxLength()
@@ -282,7 +282,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, 'a');
         $this->assertFieldValidateValue('', $descriptor, null);
         $this->assertFieldValidateValue('', $descriptor, '');
-        $this->assertFieldValidateValue('name: value is above maximum length (aaa)', $descriptor, 'aaa');
+        $this->assertFieldValidateValue('name: value is above maximum length ("aaa")', $descriptor, 'aaa');
     }
 
     protected function assertFieldValidateValue($expectedErrors, $descriptor, $value)

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -89,10 +89,10 @@ class FieldTest extends TestCase
     public function testCastValueConstraintError()
     {
         try {
-            FieldsFactory::field($this->DESCRIPTOR_MAX)->castValue('');
+            FieldsFactory::field($this->DESCRIPTOR_MAX)->castValue(null);
             $this->fail();
         } catch (FieldValidationException $e) {
-            $this->assertEquals('id: field is required ("")', $e->getMessage());
+            $this->assertEquals('id: field is required (null)', $e->getMessage());
         }
     }
 
@@ -104,7 +104,7 @@ class FieldTest extends TestCase
         );
         $this->assertEquals(
             null,
-            FieldsFactory::field($this->DESCRIPTOR_MAX)->disableConstraints()->castValue('')
+            FieldsFactory::field($this->DESCRIPTOR_MAX)->disableConstraints()->castValue(null)
         );
     }
 
@@ -124,13 +124,13 @@ class FieldTest extends TestCase
     {
         $this->assertFieldValidateValue('', $this->DESCRIPTOR_MAX, '1');
         $this->assertFieldValidateValue('id: value must be numeric ("string")', $this->DESCRIPTOR_MAX, 'string');
-        $this->assertFieldValidateValue('id: field is required ("")', $this->DESCRIPTOR_MAX, '');
+        $this->assertFieldValidateValue('id: field is required (null)', $this->DESCRIPTOR_MAX, null);
     }
 
     public function testValidateValueDisableConstraints()
     {
         $this->assertEquals([], FieldsFactory::field($this->DESCRIPTOR_MIN)->disableConstraints()->validateValue(''));
-        $this->assertEquals([], FieldsFactory::field($this->DESCRIPTOR_MAX)->disableConstraints()->validateValue(''));
+        $this->assertEquals([], FieldsFactory::field($this->DESCRIPTOR_MAX)->disableConstraints()->validateValue(null));
     }
 
     public function testStringMissingValues()
@@ -223,7 +223,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, '1');
         $this->assertFieldValidateValue('', $descriptor, 2);
         $this->assertFieldValidateValue('', $descriptor, '3');
-        $this->assertFieldValidateValue('name: value not in enum ("4")', $descriptor, '4');
+        $this->assertFieldValidateValue('name: value not in enum (4)', $descriptor, '4');
         $this->assertFieldValidateValue('name: value not in enum (4)', $descriptor, 4);
     }
 
@@ -238,7 +238,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, 2);
         $this->assertFieldValidateValue('', $descriptor, '1');
         $this->assertFieldValidateValue('', $descriptor, 1);
-        $this->assertFieldValidateValue('name: value is below minimum ("0")', $descriptor, '0');
+        $this->assertFieldValidateValue('name: value is below minimum (0)', $descriptor, '0');
         $this->assertFieldValidateValue('name: value is below minimum (0)', $descriptor, 0);
     }
 
@@ -253,7 +253,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, 0);
         $this->assertFieldValidateValue('', $descriptor, '1');
         $this->assertFieldValidateValue('', $descriptor, 1);
-        $this->assertFieldValidateValue('name: value is above maximum ("2")', $descriptor, '2');
+        $this->assertFieldValidateValue('name: value is above maximum (2)', $descriptor, '2');
         $this->assertFieldValidateValue('name: value is above maximum (2)', $descriptor, 2);
     }
 

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -13,85 +13,85 @@ class FieldTypesTest extends TestCase
 
     public function testAny()
     {
-        $this->assertFieldTestData("any", [
+        $this->assertFieldTestData('any', [
             ['default', 1, 1],
             ['default', '1', '1'],
             ['default', '3.14', '3.14'],
             ['default', true, true],
             ['default', '', ''],
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]],
-                null, null], // any field has no empty value, so required without enum is meaningless
-            [(object)[
-                "format" => 'default',
-                "constraints" => (object)["required" => true, "enum" => ["test", 1, false]]
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]],
+                null, null, ], // any field has no empty value, so required without enum is meaningless
+            [(object) [
+                'format' => 'default',
+                'constraints' => (object) ['required' => true, 'enum' => ['test', 1, false]],
             ], null, self::ERROR],
-            [(object)[
-                "format" => 'default',
-                "constraints" => (object)["required" => true, "enum" => ["test", 1, false]]
-            ], "FOO", self::ERROR],
-            [(object)[
-                "format" => 'default',
-                "constraints" => (object)["required" => true, "enum" => ["test", 1, false]]
+            [(object) [
+                'format' => 'default',
+                'constraints' => (object) ['required' => true, 'enum' => ['test', 1, false]],
+            ], 'FOO', self::ERROR],
+            [(object) [
+                'format' => 'default',
+                'constraints' => (object) ['required' => true, 'enum' => ['test', 1, false]],
             ], false, false],
-            [(object)[
-                "format" => 'default',
-                "constraints" => (object)["required" => true, "enum" => ["test", 1, null, false]]
+            [(object) [
+                'format' => 'default',
+                'constraints' => (object) ['required' => true, 'enum' => ['test', 1, null, false]],
             ], null, null],
         ]);
     }
-    
+
     public function testArray()
     {
-        $this->assertFieldTestData("array", [
+        $this->assertFieldTestData('array', [
             ['default', [], []],
             ['default', '[]', []],
             ['default', ['key', 'value'], ['key', 'value']],
             ['default', '["key", "value"]', ['key', 'value']],
-            ['default', (object)['key' => 'value'], self::ERROR],
+            ['default', (object) ['key' => 'value'], self::ERROR],
             ['default', '{"key": "value"}', self::ERROR],
             ['default', 'string', self::ERROR],
             ['default', 1, self::ERROR],
             ['default', '3.14', self::ERROR],
-            ['default', '', self::ERROR],  # missingValues is handled at the schema level
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]],
-                null, self::ERROR],
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]],
-                [], []],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]],
+                null, self::ERROR, ],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]],
+                [], [], ],
             // enum
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => [[1,2], ["foo", "bar"]]],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => [[1, 2], ['foo', 'bar']]],
             ], [], self::ERROR],
-            [(object)[
-                "format" => 'default', "constraints" => (object)[
-                    "required" => true,
-                    "enum" => [[1,2], ["foo", "bar"]]],
-            ], "[1,2]", [1,2]],
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => [[1,2], ["foo", "bar"]]],
-            ], [1,2], [1,2]],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) [
+                    'required' => true,
+                    'enum' => [[1, 2], ['foo', 'bar']], ],
+            ], '[1,2]', [1, 2]],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => [[1, 2], ['foo', 'bar']]],
+            ], [1, 2], [1, 2]],
             // minLength / maxLength
-            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1], ], [], self::ERROR],
-            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1], ], [1], [1]],
-            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1], ], [1,2], [1,2]],
-            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1], ], "invalid", self::ERROR],
-            [(object)["format" => 'default', "constraints" => (object)["maxLength" => 1], ], [], []],
-            [(object)["format" => 'default', "constraints" => (object)["maxLength" => 1], ], [1], [1]],
-            [(object)["format" => 'default', "constraints" => (object)["maxLength" => 1], ], [1,2], self::ERROR],
-            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1, "maxLength" => 1],],
-                [1,2], self::ERROR],
-            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1, "maxLength" => 1],],
-                [1], [1]],
-            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1, "maxLength" => 1],],
-                [], self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['minLength' => 1]], [], self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['minLength' => 1]], [1], [1]],
+            [(object) ['format' => 'default', 'constraints' => (object) ['minLength' => 1]], [1, 2], [1, 2]],
+            [(object) ['format' => 'default', 'constraints' => (object) ['minLength' => 1]], 'invalid', self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['maxLength' => 1]], [], []],
+            [(object) ['format' => 'default', 'constraints' => (object) ['maxLength' => 1]], [1], [1]],
+            [(object) ['format' => 'default', 'constraints' => (object) ['maxLength' => 1]], [1, 2], self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['minLength' => 1, 'maxLength' => 1]],
+                [1, 2], self::ERROR, ],
+            [(object) ['format' => 'default', 'constraints' => (object) ['minLength' => 1, 'maxLength' => 1]],
+                [1], [1], ],
+            [(object) ['format' => 'default', 'constraints' => (object) ['minLength' => 1, 'maxLength' => 1]],
+                [], self::ERROR, ],
         ]);
     }
 
     public function testBoolean()
     {
-        $this->assertFieldTestData("boolean", [
+        $this->assertFieldTestData('boolean', [
             ['default', true, true],
-            [(object)["format" => 'default', "trueValues" => ["yes"]], 'yes', true],
+            [(object) ['format' => 'default', 'trueValues' => ['yes']], 'yes', true],
             ['default', 'y', self::ERROR],
             ['default', 'true', true],
             ['default', 't', self::ERROR],
@@ -102,290 +102,286 @@ class FieldTypesTest extends TestCase
             ['default', 'no', self::ERROR],
             ['default', 'n', self::ERROR],
             ['default', 'false', false],
-            [(object)["format" => 'default', "falseValues" => ["f"]], 'f', false],
+            [(object) ['format' => 'default', 'falseValues' => ['f']], 'f', false],
             ['default', '0', false],
             ['default', 'NO', self::ERROR],
             ['default', 'No', self::ERROR],
             ['default', 0, self::ERROR],
             ['default', 1, self::ERROR],
             ['default', '3.14', self::ERROR],
-            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level,
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => [false]],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => [false]],
             ], true, self::ERROR],
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => [false]],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => [false]],
             ], false, false],
         ]);
     }
 
     public function testDate()
     {
-        $this->assertFieldTestData("date", [
+        $this->assertFieldTestData('date', [
             ['default', '2019-01-01', Carbon::create(2019, 1, 1, 0, 0, 0)],
             ['default', '10th Jan 1969', self::ERROR],
             ['default', 'invalid', self::ERROR],
-            ['default', True, self::ERROR],
-            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['default', true, self::ERROR],
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level,
             ['any', '2019-01-01', Carbon::create(2019, 1, 1, 0, 0, 0)],
             ['any', '10th Jan 1969', Carbon::create(1969, 1, 10, 0, 0, 0)],
             ['any', '10th Jan nineteen sixty nine', self::ERROR],
             ['any', 'invalid', self::ERROR],
-            ['any', True, self::ERROR],
+            ['any', true, self::ERROR],
             ['%d/%m/%y', '21/11/06', Carbon::create(2006, 11, 21, 0, 0, 0)],
-            ['%y/%m/%d','21/11/06 16:30', self::ERROR],
-            ['%d/%m/%y','invalid', self::ERROR],
-            ['%d/%m/%y',True, self::ERROR],
-            ['%d/%m/%y', '', self::ERROR],  # missingValues is handled at the schema level,
-            ['invalid','21/11/06 16:30', self::ERROR],
+            ['%y/%m/%d', '21/11/06 16:30', self::ERROR],
+            ['%d/%m/%y', 'invalid', self::ERROR],
+            ['%d/%m/%y', true, self::ERROR],
+            ['%d/%m/%y', '', self::ERROR],  // missingValues is handled at the schema level,
+            ['invalid', '21/11/06 16:30', self::ERROR],
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => ['2019-01-01']],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => ['2019-01-01']],
             ], '2019-01-01', Carbon::create(2019, 1, 1, 0, 0, 0)],
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => ['2019-01-01']],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => ['2019-01-01']],
             ], '2019-01-02', self::ERROR],
         ]);
     }
-    
 
     public function testDatetime()
     {
-        $this->assertFieldTestData("datetime", [
-            ['default', '2014-01-01T06:00:00Z', Carbon::create(2014, 1, 1, 6, 0, 0, "UTC")],
+        $this->assertFieldTestData('datetime', [
+            ['default', '2014-01-01T06:00:00Z', Carbon::create(2014, 1, 1, 6, 0, 0, 'UTC')],
             ['default', 'Mon 1st Jan 2014 9 am', self::ERROR],
             ['default', 'invalid', self::ERROR],
-            ['default', True, self::ERROR],
+            ['default', true, self::ERROR],
             ['default', 'xxx-yy-zzTfo-ob:arZ', self::ERROR],
-            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
-            ['any', Carbon::create(2014, 1, 1, 6), Carbon::create(2014, 1, 1, 6, 0, 0, "UTC")],
-            ['any', '10th Jan 1969 9 am', Carbon::create(1969, 1, 10, 9, 0, 0, "UTC")],
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level,
+            ['any', Carbon::create(2014, 1, 1, 6), Carbon::create(2014, 1, 1, 6, 0, 0, 'UTC')],
+            ['any', '10th Jan 1969 9 am', Carbon::create(1969, 1, 10, 9, 0, 0, 'UTC')],
             ['any', 'invalid', self::ERROR],
-            ['any', True, self::ERROR],
+            ['any', true, self::ERROR],
             ['%d/%m/%y %H:%M', '21/11/06 16:30', Carbon::create(2006, 11, 21, 16, 30, 0)],
             ['%H:%M %d/%m/%y', '21/11/06 16:30', self::ERROR],
             ['%d/%m/%y %H:%M', 'invalid', self::ERROR],
-            ['%d/%m/%y %H:%M', True, self::ERROR],
-            ['%d/%m/%y %H:%M', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['%d/%m/%y %H:%M', true, self::ERROR],
+            ['%d/%m/%y %H:%M', '', self::ERROR],  // missingValues is handled at the schema level,
             ['invalid', '21/11/06 16:30', self::ERROR],
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => ['2014-01-01T06:00:00Z']],
-            ], '2014-01-01T06:00:00Z', Carbon::create(2014, 1, 1, 6, 0, 0, "UTC")],
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => ['2014-01-01T06:00:00Z']],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => ['2014-01-01T06:00:00Z']],
+            ], '2014-01-01T06:00:00Z', Carbon::create(2014, 1, 1, 6, 0, 0, 'UTC')],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => ['2014-01-01T06:00:00Z']],
             ], '2014-01-01T06:01:00Z', self::ERROR],
         ]);
     }
 
     public function testDuration()
     {
-        $this->assertFieldTestData("duration", [
+        $this->assertFieldTestData('duration', [
             ['default', 'P1Y10M3DT5H11M7S', new CarbonInterval(1, 10, 0, 3, 5, 11, 7)],
             ['default', 'P1Y', new CarbonInterval(1)],
             ['default', 'P1M', new CarbonInterval(0, 1)],
             ['default', 'P1M1Y', self::ERROR],
             ['default', 'P-1Y', self::ERROR],
             ['default', 'year', self::ERROR],
-            ['default', True, self::ERROR],
-            ['default', False, self::ERROR],
+            ['default', true, self::ERROR],
+            ['default', false, self::ERROR],
             ['default', 1, self::ERROR],
-            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level,
             ['default', [], self::ERROR],
-            ['default', (object)[], self::ERROR],
+            ['default', (object) [], self::ERROR],
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => ['P1Y10M3DT5H11M7S']],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => ['P1Y10M3DT5H11M7S']],
             ], 'P1Y10M3DT5H11M7S', new CarbonInterval(1, 10, 0, 3, 5, 11, 7)],
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => ['P1Y10M3DT5H11M7S']],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => ['P1Y10M3DT5H11M7S']],
             ], 'P1Y10M3DT5H11M8S', self::ERROR],
         ]);
     }
 
     public function testGeojson()
     {
-        $this->assertFieldTestData("geojson", [
+        $this->assertFieldTestData('geojson', [
             [
                 'default',
-                (object)['properties' => (object)['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null],
-                (object)['properties' => (object)['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null]
+                (object) ['properties' => (object) ['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null],
+                (object) ['properties' => (object) ['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null],
             ],
             [
                 'default',
                 '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}',
-                (object)['properties' => (object)['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null]
+                (object) ['properties' => (object) ['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null],
             ],
             [
                 'default',
-                (object)['coordinates' => [0, 0, 0], 'type' => 'Point'],
-                (object)['coordinates' => [0, 0, 0], 'type' => 'Point']
+                (object) ['coordinates' => [0, 0, 0], 'type' => 'Point'],
+                (object) ['coordinates' => [0, 0, 0], 'type' => 'Point'],
             ],
             ['default', 'string', self::ERROR],
             ['default', 1, self::ERROR],
             ['default', '3.14', self::ERROR],
-            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
-            ['default', (object)[], self::ERROR],
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level,
+            ['default', (object) [], self::ERROR],
             ['default', '{}', self::ERROR],
             [
                 'topojson',
-                (object)['type' => 'LineString', 'arcs' => [42]],
-                (object)['type' => 'LineString', 'arcs' => [42]]
+                (object) ['type' => 'LineString', 'arcs' => [42]],
+                (object) ['type' => 'LineString', 'arcs' => [42]],
             ],
             [
                 'topojson',
                 '{"type": "LineString", "arcs": [42]}',
-                (object)['type' => 'LineString', 'arcs' => [42]]
+                (object) ['type' => 'LineString', 'arcs' => [42]],
             ],
             ['topojson', 'string', self::ERROR],
             ['topojson', 1, self::ERROR],
             ['topojson', '3.14', self::ERROR],
             ['topojson', '', self::ERROR],
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => ['{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}']],
-            ], '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}', (object)['properties' => (object)['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null]],
-            [(object)[
-                "format" => 'default', "constraints" => (object)["enum" => ['{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}']],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => ['{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}']],
+            ], '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}', (object) ['properties' => (object) ['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null]],
+            [(object) [
+                'format' => 'default', 'constraints' => (object) ['enum' => ['{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}']],
             ], '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c4"}}', self::ERROR],
         ]);
     }
 
-
     public function testGeopoint()
     {
-        $this->assertFieldTestData("geopoint", [
+        $this->assertFieldTestData('geopoint', [
             ['default',  [180, 90],  self::ERROR],
             ['default', [180, 90],  self::ERROR],
             ['default', '180,90',  [180, 90]],
             ['default', '180, -90',  [180, -90]],
-            ['default', (object)['lon' => 180, 'lat' => 90], self::ERROR],
+            ['default', (object) ['lon' => 180, 'lat' => 90], self::ERROR],
             ['default', '181,90', self::ERROR],
             ['default', '0,91', self::ERROR],
             ['default', 'string', self::ERROR],
             ['default', 1, self::ERROR],
             ['default', '3.14', self::ERROR],
-            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level,
             ['array',  [180, 90],  [180, 90]],
             ['array', [180, 90],  [180, 90]],
             ['array', '[180, -90]',  [180, -90]],
-            ['array', (object)['lon' => 180, 'lat' => 90], self::ERROR],
+            ['array', (object) ['lon' => 180, 'lat' => 90], self::ERROR],
             ['array', [181, 90], self::ERROR],
             ['array', [0, 91], self::ERROR],
             ['array', '180,90', self::ERROR],
             ['array', 'string', self::ERROR],
             ['array', 1, self::ERROR],
             ['array', '3.14', self::ERROR],
-            ['array', '', self::ERROR],  # missingValues is handled at the schema level,
-            ['object', (object)['lon' => 180, 'lat' => 90],  [180, 90]],
+            ['array', '', self::ERROR],  // missingValues is handled at the schema level,
+            ['object', (object) ['lon' => 180, 'lat' => 90],  [180, 90]],
             ['object', '{"lon":180, "lat":90}',  [180, 90]],
             ['object', '{"lat":90, "lon":180, "foo": "bar"}',  [180, 90]],
             ['object', '[180, -90]', self::ERROR],
-            ['object', (object)['lon' => 181, 'lat' => 90], self::ERROR],
-            ['object', (object)['lon' => 180, 'lat' => -91], self::ERROR],
+            ['object', (object) ['lon' => 181, 'lat' => 90], self::ERROR],
+            ['object', (object) ['lon' => 180, 'lat' => -91], self::ERROR],
             ['object', [180, -90], self::ERROR],
             ['object', '180,90', self::ERROR],
             ['object', 'string', self::ERROR],
             ['object', 1, self::ERROR],
             ['object', '3.14', self::ERROR],
-            ['object', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['object', '', self::ERROR],  // missingValues is handled at the schema level,
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)["format" => 'array', "constraints" => (object)["enum" => ['[180, -90]']]], '[180, -90]', [180, -90]],
-            [(object)["format" => 'array', "constraints" => (object)["enum" => ['[180, -90]']]], '[171, -90]', self::ERROR],
+            [(object) ['format' => 'array', 'constraints' => (object) ['enum' => ['[180, -90]']]], '[180, -90]', [180, -90]],
+            [(object) ['format' => 'array', 'constraints' => (object) ['enum' => ['[180, -90]']]], '[171, -90]', self::ERROR],
         ]);
     }
 
-
-
     public function testInteger()
     {
-        $this->assertFieldTestData("integer", [
+        $this->assertFieldTestData('integer', [
             ['default', 1, 1],
             ['default', '1', 1],
             ['default', '3.14', self::ERROR],
-            ['default', "", self::ERROR],  # missingValues is handled at the schema level,
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level,
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)["format" => 'default', "constraints" => (object)["enum" => [0, "1"]]], "0", 0],
-            [(object)["format" => 'default', "constraints" => (object)["enum" => [0, "1"]]], "2", self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => [0, '1']]], '0', 0],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => [0, '1']]], '2', self::ERROR],
         ]);
     }
 
     public function testNumber()
     {
-        $this->assertFieldTestData("number", [
-            [(object)["format"=>"default"], 1, 1.0],
-            [(object)["format"=>"default"], 1, 1.0],
-            [(object)["format"=>"default"], 1.0, 1.0],
-            [(object)["format"=>"default"], '1', 1.0],
-            [(object)["format"=>"default"], '10.00', 10.0],
-            [(object)["format"=>"default"], '10.50', 10.5],
-            [(object)["format"=>"default"], '100%', 1.0],
-            [(object)["format"=>"default"], '1000‰', self::ERROR],  # spec only supports percent sign
-            [(object)["format"=>"default"], '-1000', -1000.0],
-            [(object)["format"=>"default", 'groupChar' => ','], '1,000', 1000.0],
-            [(object)["format"=>"default", 'groupChar' => ','], '10,000.00', 10000.0],
-            [(object)["format"=>"default", 'groupChar' => ','], '10,000,000.50', 10000000.5],
-            [(object)["format"=>"default", 'groupChar' => '#'], '10#000.00', 10000.0],
-            [(object)["format"=>"default", 'groupChar' => '#'], '10#000#000.50', 10000000.5],
-            [(object)["format"=>"default", 'groupChar' => '#'], '10.50', 10.5],
-            [(object)["format"=>"default", 'groupChar' => '#'], '1#000', 1000.0],
-            [(object)["format"=>"default", 'groupChar' => '#', "decimalChar" => "@"], '10#000@00', 10000.0],
-            [(object)["format"=>"default", 'groupChar' => '#', "decimalChar" => "@"], '10#000#000@50', 10000000.5],
-            [(object)["format"=>"default", 'groupChar' => '#', "decimalChar" => "@"], '10@50', 10.5],
-            [(object)["format"=>"default", 'groupChar' => '#', "decimalChar" => "@"], '1#000', 1000.0],
-            [(object)["format"=>"default", 'groupChar' => ',', "currency" => true], '10,000.00', 10000.0],
-            [(object)["format"=>"default", 'groupChar' => ',', "currency" => true], '10,000,000.00', 10000000.0],
-            [(object)["format"=>"default", "currency" => true], '$10000.00', 10000.0],
-            [(object)["format"=>"default", 'groupChar' => ',', "currency" => true], '  10,000.00 €', 10000.0],
-            [(object)["format"=>"default", 'groupChar' => ' ', "decimalChar" => ","], '10 000,00', 10000.0],
-            [(object)["format"=>"default", 'groupChar' => ' ', "decimalChar" => ","], '10 000 000,00', 10000000.0],
-            [(object)["format"=>"default", 'groupChar' => ' ', "decimalChar" => ",", "currency" => true], '10000,00 ₪', 10000.0],
-            [(object)["format"=>"default", 'groupChar' => ' ', "decimalChar" => ",", "currency" => true], '  10 000,00 £', 10000.0],
-            [(object)["format"=>"default"], '10,000a.00', self::ERROR],
-            [(object)["format"=>"default"], '10+000.00', self::ERROR],
-            [(object)["format"=>"default"], '$10:000.00', self::ERROR],
-            [(object)["format"=>"default"], 'string', self::ERROR],
-            [(object)["format"=>"default"], '', self::ERROR],  # missingValues is handled at the schema level,
+        $this->assertFieldTestData('number', [
+            [(object) ['format' => 'default'], 1, 1.0],
+            [(object) ['format' => 'default'], 1, 1.0],
+            [(object) ['format' => 'default'], 1.0, 1.0],
+            [(object) ['format' => 'default'], '1', 1.0],
+            [(object) ['format' => 'default'], '10.00', 10.0],
+            [(object) ['format' => 'default'], '10.50', 10.5],
+            [(object) ['format' => 'default'], '100%', 1.0],
+            [(object) ['format' => 'default'], '1000‰', self::ERROR],  // spec only supports percent sign
+            [(object) ['format' => 'default'], '-1000', -1000.0],
+            [(object) ['format' => 'default', 'groupChar' => ','], '1,000', 1000.0],
+            [(object) ['format' => 'default', 'groupChar' => ','], '10,000.00', 10000.0],
+            [(object) ['format' => 'default', 'groupChar' => ','], '10,000,000.50', 10000000.5],
+            [(object) ['format' => 'default', 'groupChar' => '#'], '10#000.00', 10000.0],
+            [(object) ['format' => 'default', 'groupChar' => '#'], '10#000#000.50', 10000000.5],
+            [(object) ['format' => 'default', 'groupChar' => '#'], '10.50', 10.5],
+            [(object) ['format' => 'default', 'groupChar' => '#'], '1#000', 1000.0],
+            [(object) ['format' => 'default', 'groupChar' => '#', 'decimalChar' => '@'], '10#000@00', 10000.0],
+            [(object) ['format' => 'default', 'groupChar' => '#', 'decimalChar' => '@'], '10#000#000@50', 10000000.5],
+            [(object) ['format' => 'default', 'groupChar' => '#', 'decimalChar' => '@'], '10@50', 10.5],
+            [(object) ['format' => 'default', 'groupChar' => '#', 'decimalChar' => '@'], '1#000', 1000.0],
+            [(object) ['format' => 'default', 'groupChar' => ',', 'currency' => true], '10,000.00', 10000.0],
+            [(object) ['format' => 'default', 'groupChar' => ',', 'currency' => true], '10,000,000.00', 10000000.0],
+            [(object) ['format' => 'default', 'currency' => true], '$10000.00', 10000.0],
+            [(object) ['format' => 'default', 'groupChar' => ',', 'currency' => true], '  10,000.00 €', 10000.0],
+            [(object) ['format' => 'default', 'groupChar' => ' ', 'decimalChar' => ','], '10 000,00', 10000.0],
+            [(object) ['format' => 'default', 'groupChar' => ' ', 'decimalChar' => ','], '10 000 000,00', 10000000.0],
+            [(object) ['format' => 'default', 'groupChar' => ' ', 'decimalChar' => ',', 'currency' => true], '10000,00 ₪', 10000.0],
+            [(object) ['format' => 'default', 'groupChar' => ' ', 'decimalChar' => ',', 'currency' => true], '  10 000,00 £', 10000.0],
+            [(object) ['format' => 'default'], '10,000a.00', self::ERROR],
+            [(object) ['format' => 'default'], '10+000.00', self::ERROR],
+            [(object) ['format' => 'default'], '$10:000.00', self::ERROR],
+            [(object) ['format' => 'default'], 'string', self::ERROR],
+            [(object) ['format' => 'default'], '', self::ERROR],  // missingValues is handled at the schema level,
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)["format" => 'default', "constraints" => (object)["enum" => [0.5, "1.6"]]], "1.6", 1.6],
-            [(object)["format" => 'default', "constraints" => (object)["enum" => [0.5, "1.6"]]], "0.55", self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => [0.5, '1.6']]], '1.6', 1.6],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => [0.5, '1.6']]], '0.55', self::ERROR],
         ]);
     }
 
     public function testObject()
     {
-        $this->assertFieldTestData("object", [
-            ['default', (object)[], (object)[]],
-            ['default', '{}', (object)[]],
-            ['default', (object)['key' => 'value'], (object)['key' => 'value']],
-            ['default', '{"key": "value"}', (object)['key' => 'value']],
+        $this->assertFieldTestData('object', [
+            ['default', (object) [], (object) []],
+            ['default', '{}', (object) []],
+            ['default', (object) ['key' => 'value'], (object) ['key' => 'value']],
+            ['default', '{"key": "value"}', (object) ['key' => 'value']],
             ['default', '["key", "value"]', self::ERROR],
             ['default', 'string', self::ERROR],
             ['default', 1, self::ERROR],
             ['default', '3.14', self::ERROR],
-            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['default', '', self::ERROR],  // missingValues is handled at the schema level,
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)["format" => 'default', "constraints" => (object)["enum" => ['{"foo":"bar"}']]], '{"foo":"bar"}', (object)['foo' => 'bar']],
-            [(object)["format" => 'default', "constraints" => (object)["enum" => ['{"foo":"bar"}']]], '{"foox":"bar"}', self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => ['{"foo":"bar"}']]], '{"foo":"bar"}', (object) ['foo' => 'bar']],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => ['{"foo":"bar"}']]], '{"foox":"bar"}', self::ERROR],
         ]);
     }
 
@@ -408,11 +404,11 @@ class FieldTypesTest extends TestCase
             ['binary', 'dGVzdA==', 'dGVzdA=='],
             ['binary', '', ''],
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], '', ''],
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], '', ''],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)["format" => 'default', "constraints" => (object)["enum" => ['foobar']]], 'foobar', 'foobar'],
-            [(object)["format" => 'default', "constraints" => (object)["enum" => ['foobar']]], 'foobarx', self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => ['foobar']]], 'foobar', 'foobar'],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => ['foobar']]], 'foobarx', self::ERROR],
         ]);
     }
 
@@ -446,10 +442,10 @@ class FieldTypesTest extends TestCase
             ['%H:%M:%S', '06:35:21', [6, 35, 21]],
             ['%H:%M', '06:35:21', self::ERROR],
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)["format" => 'default', "constraints" => (object)["enum" => ['06:00:00']]], '06:00:00', [6, 0, 0]],
-            [(object)["format" => 'default', "constraints" => (object)["enum" => ['06:00:00']]], '06:01:00', self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => ['06:00:00']]], '06:00:00', [6, 0, 0]],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => ['06:00:00']]], '06:01:00', self::ERROR],
         ]);
     }
 
@@ -462,10 +458,10 @@ class FieldTypesTest extends TestCase
             ['default', 20000, 20000],
             ['default', '3.14', self::ERROR],
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)["format" => 'default', "constraints" => (object)["enum" => [2000]]], '2000', 2000],
-            [(object)["format" => 'default', "constraints" => (object)["enum" => [2000]]], '2001', self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => [2000]]], '2000', 2000],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => [2000]]], '2001', self::ERROR],
         ]);
     }
 
@@ -486,10 +482,10 @@ class FieldTypesTest extends TestCase
             ['default', '3.14', self::ERROR],
             ['default', '', self::ERROR],
             // required
-            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['required' => true]], null, self::ERROR],
             // enum
-            [(object)["format" => 'default', "constraints" => (object)["enum" => [[2000, 10]]]], '2000-10', [2000, 10]],
-            [(object)["format" => 'default', "constraints" => (object)["enum" => [[2000, 10]]]], '2000-11', self::ERROR],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => [[2000, 10]]]], '2000-10', [2000, 10]],
+            [(object) ['format' => 'default', 'constraints' => (object) ['enum' => [[2000, 10]]]], '2000-11', self::ERROR],
         ]);
     }
 
@@ -506,9 +502,9 @@ class FieldTypesTest extends TestCase
             } else {
                 $descriptor = (object) ['type' => $fieldType, 'format' => $format];
             }
-            $assertMessage = "descriptor=".json_encode($descriptor).", input='".json_encode($inputValue)."', expected='".json_encode($expectedCastValue)."'";
+            $assertMessage = 'descriptor='.json_encode($descriptor).", input='".json_encode($inputValue)."', expected='".json_encode($expectedCastValue)."'";
             if (!isset($descriptor->name)) {
-                $descriptor->name = "unknown";
+                $descriptor->name = 'unknown';
             }
             $field = FieldsFactory::field($descriptor);
             if ($expectedCastValue === self::ERROR) {

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -2,18 +2,12 @@
 
 namespace frictionlessdata\tableschema\tests;
 
-use frictionlessdata\tableschema\DataSources\NativeDataSource;
-use frictionlessdata\tableschema\Exceptions\DataSourceException;
-use frictionlessdata\tableschema\Exceptions\FieldValidationException;
-use frictionlessdata\tableschema\Schema;
-use frictionlessdata\tableschema\SchemaValidationError;
-use frictionlessdata\tableschema\Table;
 use PHPUnit\Framework\TestCase;
 use frictionlessdata\tableschema\Fields\FieldsFactory;
 
 class FieldTypesTest extends TestCase
 {
-    const ERROR = "~~ERROR~~";
+    const ERROR = '~~ERROR~~';
 
     /*
 
@@ -247,11 +241,11 @@ class FieldTypesTest extends TestCase
      */
     public function testString()
     {
-        $this->assertFieldTestData("string", [
+        $this->assertFieldTestData('string', [
             // format , input value , expected cast value, (optional) expected infer type
             ['default', 'string', 'string'],
             ['default', '', ''],
-            ['default', 0, "0"],
+            ['default', 0, '0'],
             ['uri', 'http://google.com', 'http://google.com'],
             ['uri', 'string', self::ERROR],
             ['uri', '', self::ERROR],
@@ -270,7 +264,7 @@ class FieldTypesTest extends TestCase
     {
         $native_time_6 = mktime(6, 0, 0);
         $native_time_3 = mktime(3, 0, 0);
-        $this->assertFieldTestData("time", [
+        $this->assertFieldTestData('time', [
             // format , input value , expected cast value, (optional) expected infer type
             ['default', '06:00:00', $native_time_6],
             ['default', '3 am', self::ERROR],
@@ -303,23 +297,23 @@ class FieldTypesTest extends TestCase
 
     public function testYear()
     {
-        $this->assertFieldTestData("year", [
+        $this->assertFieldTestData('year', [
             // format , input value , expected cast value, (optional) expected infer type
             ['default', 2000, 2000],
             ['default', '2000', 2000],
             ['default', 20000, 20000],
             ['default', '3.14', self::ERROR],
-            ['default', '', self::ERROR]
+            ['default', '', self::ERROR],
         ]);
     }
 
     public function testYearMonth()
     {
-        $this->assertFieldTestData("yearmonth", [
+        $this->assertFieldTestData('yearmonth', [
             // format , input value , expected cast value, (optional) expected infer type
             ['default', [2000, 10], [2000, 10]],
-            ['default', [2000, 10], [2000, 10], "string"],
-            ['default', '2000-10', [2000, 10], "string"],
+            ['default', [2000, 10], [2000, 10], 'string'],
+            ['default', '2000-10', [2000, 10], 'string'],
             ['default', [2000, 10, 20], self::ERROR],
             ['default', '2000-13-20', self::ERROR],
             ['default', '2000-13', self::ERROR],
@@ -335,10 +329,12 @@ class FieldTypesTest extends TestCase
     protected function assertFieldTestData($fieldType, $testData)
     {
         foreach ($testData as $testLine) {
-            if (!isset($testLine[3])) $testLine[3] = null;
+            if (!isset($testLine[3])) {
+                $testLine[3] = null;
+            }
             list($format, $inputValue, $expectedCastValue, $expectedInferType) = $testLine;
             $assertMessage = "format='{$format}', input='".json_encode($inputValue)."', expected='".json_encode($expectedCastValue)."'";
-            $field = FieldsFactory::field((object)["type" => $fieldType, "format" => $format]);
+            $field = FieldsFactory::field((object) ['type' => $fieldType, 'format' => $format]);
             if ($expectedCastValue == self::ERROR) {
                 $this->assertTrue(count($field->validateValue($inputValue)) > 0, $assertMessage);
             } else {

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace frictionlessdata\tableschema\tests;
+
+use frictionlessdata\tableschema\DataSources\NativeDataSource;
+use frictionlessdata\tableschema\Exceptions\DataSourceException;
+use frictionlessdata\tableschema\Exceptions\FieldValidationException;
+use frictionlessdata\tableschema\Schema;
+use frictionlessdata\tableschema\SchemaValidationError;
+use frictionlessdata\tableschema\Table;
+use PHPUnit\Framework\TestCase;
+use frictionlessdata\tableschema\Fields\FieldsFactory;
+
+class FieldTypesTest extends TestCase
+{
+    const ERROR = "~~ERROR~~";
+
+    /*
+
+    any
+
+    ('default', 1, 1),
+    ('default', '1', '1'),
+    ('default', '3.14', '3.14'),
+    ('default', True, True),
+    ('default', '', ''),
+
+    array
+
+    ('default', [], []),
+    ('default', '[]', []),
+    ('default', ['key', 'value'], ['key', 'value']),
+    ('default', '["key", "value"]', ['key', 'value']),
+    ('default', {'key': 'value'}, ERROR),
+    ('default', '{"key": "value"}', ERROR),
+    ('default', 'string', ERROR),
+    ('default', 1, ERROR),
+    ('default', '3.14', ERROR),
+    ('default', '', ERROR),
+
+    boolean
+    ('default', True, True),
+    ('default', 'yes', True),
+    ('default', 'y', True),
+    ('default', 'true', True),
+    ('default', 't', True),
+    ('default', '1', True),
+    ('default', 'YES', True),
+    ('default', 'Yes', True),
+    ('default', False, False),
+    ('default', 'no', False),
+    ('default', 'n', False),
+    ('default', 'false', False),
+    ('default', 'f', False),
+    ('default', '0', False),
+    ('default', 'NO', False),
+    ('default', 'No', False),
+    ('default', 0, ERROR),
+    ('default', 1, ERROR),
+    ('default', '3.14', ERROR),
+    ('default', '', ERROR),
+
+    date
+    ('default', date(2019, 1, 1), date(2019, 1, 1)),
+    ('default', '2019-01-01', date(2019, 1, 1)),
+    ('default', '10th Jan 1969', ERROR),
+    ('default', 'invalid', ERROR),
+    ('default', True, ERROR),
+    ('default', '', ERROR),
+    ('any', date(2019, 1, 1), date(2019, 1, 1)),
+    ('any', '2019-01-01', date(2019, 1, 1)),
+    ('any', '10th Jan 1969', date(1969, 1, 10)),
+    ('any', '10th Jan nineteen sixty nine', ERROR),
+    ('any', 'invalid', ERROR),
+    ('any', True, ERROR),
+    ('any', '', ERROR),
+    ('%d/%m/%y', date(2019, 1, 1), date(2019, 1, 1)),
+    ('%d/%m/%y', '21/11/06', date(2006, 11, 21)),
+    ('%y/%m/%d','21/11/06 16:30', ERROR),
+    ('%d/%m/%y','invalid', ERROR),
+    ('%d/%m/%y',True, ERROR),
+    ('%d/%m/%y', '', ERROR),
+    ('invalid','21/11/06 16:30', ERROR),
+    # Deprecated
+    ('fmt:%d/%m/%y', date(2019, 1, 1), date(2019, 1, 1)),
+    ('fmt:%d/%m/%y', '21/11/06', date(2006, 11, 21)),
+    ('fmt:%y/%m/%d','21/11/06 16:30', ERROR),
+    ('fmt:%d/%m/%y','invalid', ERROR),
+    ('fmt:%d/%m/%y',True, ERROR),
+    ('fmt:%d/%m/%y', '', ERROR),
+
+    datetime
+    ('default', datetime(2014, 1, 1, 6), datetime(2014, 1, 1, 6)),
+    ('default', '2014-01-01T06:00:00Z', datetime(2014, 1, 1, 6)),
+    ('default', 'Mon 1st Jan 2014 9 am', ERROR),
+    ('default', 'invalid', ERROR),
+    ('default', True, ERROR),
+    ('default', '', ERROR),
+    ('any', datetime(2014, 1, 1, 6), datetime(2014, 1, 1, 6)),
+    ('any', '10th Jan 1969 9 am', datetime(1969, 1, 10, 9)),
+    ('any', 'invalid', ERROR),
+    ('any', True, ERROR),
+    ('any', '', ERROR),
+    ('%d/%m/%y %H:%M', datetime(2006, 11, 21, 16, 30), datetime(2006, 11, 21, 16, 30)),
+    ('%d/%m/%y %H:%M', '21/11/06 16:30', datetime(2006, 11, 21, 16, 30)),
+    ('%H:%M %d/%m/%y', '21/11/06 16:30', ERROR),
+    ('%d/%m/%y %H:%M', 'invalid', ERROR),
+    ('%d/%m/%y %H:%M', True, ERROR),
+    ('%d/%m/%y %H:%M', '', ERROR),
+    ('invalid', '21/11/06 16:30', ERROR),
+    # Deprecated
+    ('fmt:%d/%m/%y %H:%M', datetime(2006, 11, 21, 16, 30), datetime(2006, 11, 21, 16, 30)),
+    ('fmt:%d/%m/%y %H:%M', '21/11/06 16:30', datetime(2006, 11, 21, 16, 30)),
+    ('fmt:%H:%M %d/%m/%y', '21/11/06 16:30', ERROR),
+    ('fmt:%d/%m/%y %H:%M', 'invalid', ERROR),
+    ('fmt:%d/%m/%y %H:%M', True, ERROR),
+    ('fmt:%d/%m/%y %H:%M', '', ERROR),
+
+    duration
+    ('default', isodate.Duration(years=1), isodate.Duration(years=1)),
+    ('default', 'P1Y10M3DT5H11M7S',
+         isodate.Duration(years=1, months=10, days=3, hours=5, minutes=11, seconds=7)),
+    ('default', 'P1Y', isodate.Duration(years=1)),
+    ('default', 'P1M', isodate.Duration(months=1)),
+    ('default', 'P1M1Y', ERROR),
+    ('default', 'P-1Y', ERROR),
+    ('default', 'year', ERROR),
+    ('default', True, ERROR),
+    ('default', False, ERROR),
+    ('default', 1, ERROR),
+    ('default', '', ERROR),
+    ('default', [], ERROR),
+    ('default', {}, ERROR),
+
+    geojson
+    ('default',
+        {'properties': {'Ã': 'Ã'}, 'type': 'Feature', 'geometry': None},
+        {'properties': {'Ã': 'Ã'}, 'type': 'Feature', 'geometry': None}),
+    ('default',
+        '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}',
+        {'properties': {'Ã': 'Ã'}, 'type': 'Feature', 'geometry': None}),
+    ('default', {'coordinates': [0, 0, 0], 'type': 'Point'}, ERROR),
+    ('default', 'string', ERROR),
+    ('default', 1, ERROR),
+    ('default', '3.14', ERROR),
+    ('default', '', ERROR),
+    ('default', {}, ERROR),
+    ('default', '{}', ERROR),
+    ('topojson',
+        {'type': 'LineString', 'arcs': [42]},
+        {'type': 'LineString', 'arcs': [42]}),
+    ('topojson',
+        '{"type": "LineString", "arcs": [42]}',
+        {'type': 'LineString', 'arcs': [42]}),
+    ('topojson', 'string', ERROR),
+    ('topojson', 1, ERROR),
+    ('topojson', '3.14', ERROR),
+    ('topojson', '', ERROR),
+
+    geopoint
+    ('default', (180, 90), (180, 90)),
+    ('default', [180, 90], (180, 90)),
+    ('default', '180,90', (180, 90)),
+    ('default', '180, -90', (180, -90)),
+    ('default', {'lon': 180, 'lat': 90}, ERROR),
+    ('default', '181,90', ERROR),
+    ('default', '0,91', ERROR),
+    ('default', 'string', ERROR),
+    ('default', 1, ERROR),
+    ('default', '3.14', ERROR),
+    ('default', '', ERROR),
+    ('array', (180, 90), (180, 90)),
+    ('array', [180, 90], (180, 90)),
+    ('array', '[180, -90]', (180, -90)),
+    ('array', {'lon': 180, 'lat': 90}, ERROR),
+    ('array', [181, 90], ERROR),
+    ('array', [0, 91], ERROR),
+    ('array', '180,90', ERROR),
+    ('array', 'string', ERROR),
+    ('array', 1, ERROR),
+    ('array', '3.14', ERROR),
+    ('array', '', ERROR),
+    ('object', {'lon': 180, 'lat': 90}, (180, 90)),
+    ('object', '{"lon": 180, "lat": 90}', (180, 90)),
+    ('object', '[180, -90]', ERROR),
+    ('object', {'lon': 181, 'lat': 90}, ERROR),
+    ('object', {'lon': 180, 'lat': -91}, ERROR),
+    ('object', [180, -90], ERROR),
+    ('object', '180,90', ERROR),
+    ('object', 'string', ERROR),
+    ('object', 1, ERROR),
+    ('object', '3.14', ERROR),
+    ('object', '', ERROR),
+
+    integer
+    ('default', 1, 1),
+    ('default', '1', 1),
+    ('default', '3.14', ERROR),
+    ('default', '', ERROR),
+
+    number
+    ('default', Decimal(1), {}, Decimal(1)),
+    ('default', 1, {}, Decimal(1)),
+    ('default', 1.0, {}, Decimal(1)),
+    ('default', '1', {}, Decimal(1)),
+    ('default', '10.00', {}, Decimal(10)),
+    ('default', '10.50', {}, Decimal(10.5)),
+    ('default', '100%', {}, Decimal(1)),
+    ('default', '1000‰', {}, Decimal(10)),
+    ('default', '-1000', {}, Decimal(-1000)),
+    ('default', '1,000', {'groupChar': ','}, Decimal(1000)),
+    ('default', '10,000.00', {'groupChar': ','}, Decimal(10000)),
+    ('default', '10,000,000.50', {'groupChar': ','}, Decimal(10000000.5)),
+    ('default', '10#000.00', {'groupChar': '#'}, Decimal(10000)),
+    ('default', '10#000#000.50', {'groupChar': '#'}, Decimal(10000000.5)),
+    ('default', '10.50', {'groupChar': '#'}, Decimal(10.5)),
+    ('default', '1#000', {'groupChar': '#'}, Decimal(1000)),
+    ('default', '10#000@00', {'groupChar': '#', 'decimalChar': '@'}, Decimal(10000)),
+    ('default', '10#000#000@50', {'groupChar': '#', 'decimalChar': '@'}, Decimal(10000000.5)),
+    ('default', '10@50', {'groupChar': '#', 'decimalChar': '@'}, Decimal(10.5)),
+    ('default', '1#000', {'groupChar': '#', 'decimalChar': '@'}, Decimal(1000)),
+    ('default', '10,000.00', {'groupChar': ',', 'currency': True}, Decimal(10000)),
+    ('default', '10,000,000.00', {'groupChar': ',', 'currency': True}, Decimal(10000000)),
+    ('default', '$10000.00', {'currency': True}, Decimal(10000)),
+    ('default', '  10,000.00 €', {'groupChar': ',', 'currency': True}, Decimal(10000)),
+    ('default', '10 000,00', {'groupChar': ' ', 'decimalChar': ','}, Decimal(10000)),
+    ('default', '10 000 000,00', {'groupChar': ' ', 'decimalChar': ','}, Decimal(10000000)),
+    ('default', '10000,00 ₪', {'groupChar': ' ', 'decimalChar': ',', 'currency': True}, Decimal(10000)),
+    ('default', '  10 000,00 £', {'groupChar': ' ', 'decimalChar': ',', 'currency': True}, Decimal(10000)),
+    ('default', '10,000a.00', {}, ERROR),
+    ('default', '10+000.00', {}, ERROR),
+    ('default', '$10:000.00', {}, ERROR),
+    ('default', 'string', {}, ERROR),
+    ('default', '', {}, ERROR),
+
+    object
+    ('default', {}, {}),
+    ('default', '{}', {}),
+    ('default', {'key': 'value'}, {'key': 'value'}),
+    ('default', '{"key": "value"}', {'key': 'value'}),
+    ('default', '["key", "value"]', ERROR),
+    ('default', 'string', ERROR),
+    ('default', 1, ERROR),
+    ('default', '3.14', ERROR),
+    ('default', '', ERROR),
+
+     */
+    public function testString()
+    {
+        $this->assertFieldTestData("string", [
+            // format , input value , expected cast value, (optional) expected infer type
+            ['default', 'string', 'string'],
+            ['default', '', ''],
+            ['default', 0, "0"],
+            ['uri', 'http://google.com', 'http://google.com'],
+            ['uri', 'string', self::ERROR],
+            ['uri', '', self::ERROR],
+            ['uri', 0, self::ERROR],
+            ['email', 'name@gmail.com', 'name@gmail.com'],
+            ['email', 'http://google.com', self::ERROR],
+            ['email', 'string', self::ERROR],
+            ['email', '', self::ERROR],
+            ['email', 0, self::ERROR],
+            ['binary', 'dGVzdA==', 'dGVzdA=='],
+            ['binary', '', ''],
+        ]);
+    }
+
+    public function testTime()
+    {
+        $native_time_6 = mktime(6, 0, 0);
+        $native_time_3 = mktime(3, 0, 0);
+        $this->assertFieldTestData("time", [
+            // format , input value , expected cast value, (optional) expected infer type
+            ['default', '06:00:00', $native_time_6],
+            ['default', '3 am', self::ERROR],
+            ['default', '3.00', self::ERROR],
+            ['default', 'invalid', self::ERROR],
+            ['default', true, self::ERROR],
+            ['default', '', self::ERROR],
+            ['any', '06:00:00', $native_time_6],
+            ['any', '3:00 am', $native_time_3],
+            ['any', 'some night', self::ERROR],
+            ['any', 'invalid', self::ERROR],
+            ['any', true, self::ERROR],
+            ['any', '', self::ERROR],
+            ['%H:%M', '06:00', $native_time_6],
+            ['%H:%M', '3:00 am', self::ERROR],
+            ['%H:%M', 'some night', self::ERROR],
+            ['%H:%M', 'invalid', self::ERROR],
+            ['%H:%M', true, self::ERROR],
+            ['%H:%M', '', self::ERROR],
+            ['invalid', '', self::ERROR],
+            ['default', '06:35:21', mktime(6, 35, 21)],
+            ['any', '06:35:21', mktime(6, 35, 21)],
+            ['any', '06:35', mktime(6, 35, 0)],
+            ['any', '6', self::ERROR],
+            ['any', '3 am', mktime(3, 0, 0)],
+            ['%H:%M:%S', '06:35:21', mktime(6, 35, 21)],
+            ['%H:%M', '06:35:21', self::ERROR],
+        ]);
+    }
+
+    public function testYear()
+    {
+        $this->assertFieldTestData("year", [
+            // format , input value , expected cast value, (optional) expected infer type
+            ['default', 2000, 2000],
+            ['default', '2000', 2000],
+            ['default', 20000, 20000],
+            ['default', '3.14', self::ERROR],
+            ['default', '', self::ERROR]
+        ]);
+    }
+
+    public function testYearMonth()
+    {
+        $this->assertFieldTestData("yearmonth", [
+            // format , input value , expected cast value, (optional) expected infer type
+            ['default', [2000, 10], [2000, 10]],
+            ['default', [2000, 10], [2000, 10], "string"],
+            ['default', '2000-10', [2000, 10], "string"],
+            ['default', [2000, 10, 20], self::ERROR],
+            ['default', '2000-13-20', self::ERROR],
+            ['default', '2000-13', self::ERROR],
+            ['default', '2000-0', self::ERROR],
+            ['default', '13', self::ERROR],
+            ['default', -10, self::ERROR],
+            ['default', 20, self::ERROR],
+            ['default', '3.14', self::ERROR],
+            ['default', '', self::ERROR],
+        ]);
+    }
+
+    protected function assertFieldTestData($fieldType, $testData)
+    {
+        foreach ($testData as $testLine) {
+            if (!isset($testLine[3])) $testLine[3] = null;
+            list($format, $inputValue, $expectedCastValue, $expectedInferType) = $testLine;
+            $assertMessage = "format='{$format}', input='".json_encode($inputValue)."', expected='".json_encode($expectedCastValue)."'";
+            $field = FieldsFactory::field((object)["type" => $fieldType, "format" => $format]);
+            if ($expectedCastValue == self::ERROR) {
+                $this->assertTrue(count($field->validateValue($inputValue)) > 0, $assertMessage);
+            } else {
+                $this->assertEquals($expectedCastValue, $field->castValue($inputValue), $assertMessage);
+            }
+            $inferredType = FieldsFactory::infer($inputValue)->type();
+            if ($expectedInferType) {
+                $this->assertEquals($expectedInferType, $inferredType, $assertMessage);
+            }
+        }
+    }
+}

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -2,6 +2,7 @@
 
 namespace frictionlessdata\tableschema\tests;
 
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use frictionlessdata\tableschema\Fields\FieldsFactory;
 
@@ -262,35 +263,33 @@ class FieldTypesTest extends TestCase
 
     public function testTime()
     {
-        $native_time_6 = mktime(6, 0, 0);
-        $native_time_3 = mktime(3, 0, 0);
         $this->assertFieldTestData('time', [
             // format , input value , expected cast value, (optional) expected infer type
-            ['default', '06:00:00', $native_time_6],
+            ['default', '06:00:00', [6, 0, 0]],
             ['default', '3 am', self::ERROR],
             ['default', '3.00', self::ERROR],
             ['default', 'invalid', self::ERROR],
             ['default', true, self::ERROR],
-            ['default', '', self::ERROR],
-            ['any', '06:00:00', $native_time_6],
-            ['any', '3:00 am', $native_time_3],
+            ['default', '', null],
+            ['any', '06:00:00', [6, 0, 0]],
+            ['any', '3:00 am', [3, 0, 0]],
             ['any', 'some night', self::ERROR],
             ['any', 'invalid', self::ERROR],
             ['any', true, self::ERROR],
-            ['any', '', self::ERROR],
-            ['%H:%M', '06:00', $native_time_6],
+            ['any', '', null],
+            ['%H:%M', '06:00', [6, 0, 0]],
             ['%H:%M', '3:00 am', self::ERROR],
             ['%H:%M', 'some night', self::ERROR],
             ['%H:%M', 'invalid', self::ERROR],
             ['%H:%M', true, self::ERROR],
-            ['%H:%M', '', self::ERROR],
-            ['invalid', '', self::ERROR],
-            ['default', '06:35:21', mktime(6, 35, 21)],
-            ['any', '06:35:21', mktime(6, 35, 21)],
-            ['any', '06:35', mktime(6, 35, 0)],
+            ['%H:%M', '', null],
+            ['invalid', '', null],
+            ['default', '06:35:21', [6, 35, 21]],
+            ['any', '06:35:21', [6, 35, 21]],
+            ['any', '06:35', [6, 35, 0]],
             ['any', '6', self::ERROR],
-            ['any', '3 am', mktime(3, 0, 0)],
-            ['%H:%M:%S', '06:35:21', mktime(6, 35, 21)],
+            ['any', '3 am', [3, 0, 0]],
+            ['%H:%M:%S', '06:35:21', [6, 35, 21]],
             ['%H:%M', '06:35:21', self::ERROR],
         ]);
     }
@@ -303,7 +302,7 @@ class FieldTypesTest extends TestCase
             ['default', '2000', 2000],
             ['default', 20000, 20000],
             ['default', '3.14', self::ERROR],
-            ['default', '', self::ERROR],
+            ['default', '', null],
         ]);
     }
 
@@ -322,7 +321,7 @@ class FieldTypesTest extends TestCase
             ['default', -10, self::ERROR],
             ['default', 20, self::ERROR],
             ['default', '3.14', self::ERROR],
-            ['default', '', self::ERROR],
+            ['default', '', null],
         ]);
     }
 
@@ -338,11 +337,11 @@ class FieldTypesTest extends TestCase
             if ($expectedCastValue == self::ERROR) {
                 $this->assertTrue(count($field->validateValue($inputValue)) > 0, $assertMessage);
             } else {
-                $this->assertEquals($expectedCastValue, $field->castValue($inputValue), $assertMessage);
+                $this->assertSame($expectedCastValue, $field->castValue($inputValue), $assertMessage);
             }
             $inferredType = FieldsFactory::infer($inputValue)->type();
             if ($expectedInferType) {
-                $this->assertEquals($expectedInferType, $inferredType, $assertMessage);
+                $this->assertSame($expectedInferType, $inferredType, $assertMessage);
             }
         }
     }

--- a/tests/FieldTypesTest.php
+++ b/tests/FieldTypesTest.php
@@ -3,6 +3,7 @@
 namespace frictionlessdata\tableschema\tests;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterval;
 use PHPUnit\Framework\TestCase;
 use frictionlessdata\tableschema\Fields\FieldsFactory;
 
@@ -10,236 +11,384 @@ class FieldTypesTest extends TestCase
 {
     const ERROR = '~~ERROR~~';
 
-    /*
+    public function testAny()
+    {
+        $this->assertFieldTestData("any", [
+            ['default', 1, 1],
+            ['default', '1', '1'],
+            ['default', '3.14', '3.14'],
+            ['default', true, true],
+            ['default', '', ''],
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]],
+                null, null], // any field has no empty value, so required without enum is meaningless
+            [(object)[
+                "format" => 'default',
+                "constraints" => (object)["required" => true, "enum" => ["test", 1, false]]
+            ], null, self::ERROR],
+            [(object)[
+                "format" => 'default',
+                "constraints" => (object)["required" => true, "enum" => ["test", 1, false]]
+            ], "FOO", self::ERROR],
+            [(object)[
+                "format" => 'default',
+                "constraints" => (object)["required" => true, "enum" => ["test", 1, false]]
+            ], false, false],
+            [(object)[
+                "format" => 'default',
+                "constraints" => (object)["required" => true, "enum" => ["test", 1, null, false]]
+            ], null, null],
+        ]);
+    }
+    
+    public function testArray()
+    {
+        $this->assertFieldTestData("array", [
+            ['default', [], []],
+            ['default', '[]', []],
+            ['default', ['key', 'value'], ['key', 'value']],
+            ['default', '["key", "value"]', ['key', 'value']],
+            ['default', (object)['key' => 'value'], self::ERROR],
+            ['default', '{"key": "value"}', self::ERROR],
+            ['default', 'string', self::ERROR],
+            ['default', 1, self::ERROR],
+            ['default', '3.14', self::ERROR],
+            ['default', '', self::ERROR],  # missingValues is handled at the schema level
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]],
+                null, self::ERROR],
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]],
+                [], []],
+            // enum
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => [[1,2], ["foo", "bar"]]],
+            ], [], self::ERROR],
+            [(object)[
+                "format" => 'default', "constraints" => (object)[
+                    "required" => true,
+                    "enum" => [[1,2], ["foo", "bar"]]],
+            ], "[1,2]", [1,2]],
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => [[1,2], ["foo", "bar"]]],
+            ], [1,2], [1,2]],
+            // minLength / maxLength
+            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1], ], [], self::ERROR],
+            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1], ], [1], [1]],
+            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1], ], [1,2], [1,2]],
+            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1], ], "invalid", self::ERROR],
+            [(object)["format" => 'default', "constraints" => (object)["maxLength" => 1], ], [], []],
+            [(object)["format" => 'default', "constraints" => (object)["maxLength" => 1], ], [1], [1]],
+            [(object)["format" => 'default', "constraints" => (object)["maxLength" => 1], ], [1,2], self::ERROR],
+            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1, "maxLength" => 1],],
+                [1,2], self::ERROR],
+            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1, "maxLength" => 1],],
+                [1], [1]],
+            [(object)["format" => 'default', "constraints" => (object)["minLength" => 1, "maxLength" => 1],],
+                [], self::ERROR],
+        ]);
+    }
 
-    any
+    public function testBoolean()
+    {
+        $this->assertFieldTestData("boolean", [
+            ['default', true, true],
+            [(object)["format" => 'default', "trueValues" => ["yes"]], 'yes', true],
+            ['default', 'y', self::ERROR],
+            ['default', 'true', true],
+            ['default', 't', self::ERROR],
+            ['default', '1', true],
+            ['default', 'YES', self::ERROR],
+            ['default', 'Yes', self::ERROR],
+            ['default', false, false],
+            ['default', 'no', self::ERROR],
+            ['default', 'n', self::ERROR],
+            ['default', 'false', false],
+            [(object)["format" => 'default', "falseValues" => ["f"]], 'f', false],
+            ['default', '0', false],
+            ['default', 'NO', self::ERROR],
+            ['default', 'No', self::ERROR],
+            ['default', 0, self::ERROR],
+            ['default', 1, self::ERROR],
+            ['default', '3.14', self::ERROR],
+            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => [false]],
+            ], true, self::ERROR],
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => [false]],
+            ], false, false],
+        ]);
+    }
 
-    ('default', 1, 1),
-    ('default', '1', '1'),
-    ('default', '3.14', '3.14'),
-    ('default', True, True),
-    ('default', '', ''),
+    public function testDate()
+    {
+        $this->assertFieldTestData("date", [
+            ['default', '2019-01-01', Carbon::create(2019, 1, 1, 0, 0, 0)],
+            ['default', '10th Jan 1969', self::ERROR],
+            ['default', 'invalid', self::ERROR],
+            ['default', True, self::ERROR],
+            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['any', '2019-01-01', Carbon::create(2019, 1, 1, 0, 0, 0)],
+            ['any', '10th Jan 1969', Carbon::create(1969, 1, 10, 0, 0, 0)],
+            ['any', '10th Jan nineteen sixty nine', self::ERROR],
+            ['any', 'invalid', self::ERROR],
+            ['any', True, self::ERROR],
+            ['%d/%m/%y', '21/11/06', Carbon::create(2006, 11, 21, 0, 0, 0)],
+            ['%y/%m/%d','21/11/06 16:30', self::ERROR],
+            ['%d/%m/%y','invalid', self::ERROR],
+            ['%d/%m/%y',True, self::ERROR],
+            ['%d/%m/%y', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['invalid','21/11/06 16:30', self::ERROR],
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => ['2019-01-01']],
+            ], '2019-01-01', Carbon::create(2019, 1, 1, 0, 0, 0)],
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => ['2019-01-01']],
+            ], '2019-01-02', self::ERROR],
+        ]);
+    }
+    
 
-    array
+    public function testDatetime()
+    {
+        $this->assertFieldTestData("datetime", [
+            ['default', '2014-01-01T06:00:00Z', Carbon::create(2014, 1, 1, 6, 0, 0, "UTC")],
+            ['default', 'Mon 1st Jan 2014 9 am', self::ERROR],
+            ['default', 'invalid', self::ERROR],
+            ['default', True, self::ERROR],
+            ['default', 'xxx-yy-zzTfo-ob:arZ', self::ERROR],
+            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['any', Carbon::create(2014, 1, 1, 6), Carbon::create(2014, 1, 1, 6, 0, 0, "UTC")],
+            ['any', '10th Jan 1969 9 am', Carbon::create(1969, 1, 10, 9, 0, 0, "UTC")],
+            ['any', 'invalid', self::ERROR],
+            ['any', True, self::ERROR],
+            ['%d/%m/%y %H:%M', '21/11/06 16:30', Carbon::create(2006, 11, 21, 16, 30, 0)],
+            ['%H:%M %d/%m/%y', '21/11/06 16:30', self::ERROR],
+            ['%d/%m/%y %H:%M', 'invalid', self::ERROR],
+            ['%d/%m/%y %H:%M', True, self::ERROR],
+            ['%d/%m/%y %H:%M', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['invalid', '21/11/06 16:30', self::ERROR],
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => ['2014-01-01T06:00:00Z']],
+            ], '2014-01-01T06:00:00Z', Carbon::create(2014, 1, 1, 6, 0, 0, "UTC")],
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => ['2014-01-01T06:00:00Z']],
+            ], '2014-01-01T06:01:00Z', self::ERROR],
+        ]);
+    }
 
-    ('default', [], []),
-    ('default', '[]', []),
-    ('default', ['key', 'value'], ['key', 'value']),
-    ('default', '["key", "value"]', ['key', 'value']),
-    ('default', {'key': 'value'}, ERROR),
-    ('default', '{"key": "value"}', ERROR),
-    ('default', 'string', ERROR),
-    ('default', 1, ERROR),
-    ('default', '3.14', ERROR),
-    ('default', '', ERROR),
+    public function testDuration()
+    {
+        $this->assertFieldTestData("duration", [
+            ['default', 'P1Y10M3DT5H11M7S', new CarbonInterval(1, 10, 0, 3, 5, 11, 7)],
+            ['default', 'P1Y', new CarbonInterval(1)],
+            ['default', 'P1M', new CarbonInterval(0, 1)],
+            ['default', 'P1M1Y', self::ERROR],
+            ['default', 'P-1Y', self::ERROR],
+            ['default', 'year', self::ERROR],
+            ['default', True, self::ERROR],
+            ['default', False, self::ERROR],
+            ['default', 1, self::ERROR],
+            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['default', [], self::ERROR],
+            ['default', (object)[], self::ERROR],
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => ['P1Y10M3DT5H11M7S']],
+            ], 'P1Y10M3DT5H11M7S', new CarbonInterval(1, 10, 0, 3, 5, 11, 7)],
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => ['P1Y10M3DT5H11M7S']],
+            ], 'P1Y10M3DT5H11M8S', self::ERROR],
+        ]);
+    }
 
-    boolean
-    ('default', True, True),
-    ('default', 'yes', True),
-    ('default', 'y', True),
-    ('default', 'true', True),
-    ('default', 't', True),
-    ('default', '1', True),
-    ('default', 'YES', True),
-    ('default', 'Yes', True),
-    ('default', False, False),
-    ('default', 'no', False),
-    ('default', 'n', False),
-    ('default', 'false', False),
-    ('default', 'f', False),
-    ('default', '0', False),
-    ('default', 'NO', False),
-    ('default', 'No', False),
-    ('default', 0, ERROR),
-    ('default', 1, ERROR),
-    ('default', '3.14', ERROR),
-    ('default', '', ERROR),
+    public function testGeojson()
+    {
+        $this->assertFieldTestData("geojson", [
+            [
+                'default',
+                (object)['properties' => (object)['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null],
+                (object)['properties' => (object)['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null]
+            ],
+            [
+                'default',
+                '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}',
+                (object)['properties' => (object)['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null]
+            ],
+            [
+                'default',
+                (object)['coordinates' => [0, 0, 0], 'type' => 'Point'],
+                (object)['coordinates' => [0, 0, 0], 'type' => 'Point']
+            ],
+            ['default', 'string', self::ERROR],
+            ['default', 1, self::ERROR],
+            ['default', '3.14', self::ERROR],
+            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['default', (object)[], self::ERROR],
+            ['default', '{}', self::ERROR],
+            [
+                'topojson',
+                (object)['type' => 'LineString', 'arcs' => [42]],
+                (object)['type' => 'LineString', 'arcs' => [42]]
+            ],
+            [
+                'topojson',
+                '{"type": "LineString", "arcs": [42]}',
+                (object)['type' => 'LineString', 'arcs' => [42]]
+            ],
+            ['topojson', 'string', self::ERROR],
+            ['topojson', 1, self::ERROR],
+            ['topojson', '3.14', self::ERROR],
+            ['topojson', '', self::ERROR],
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => ['{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}']],
+            ], '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}', (object)['properties' => (object)['Ã' => 'Ã'], 'type' => 'Feature', 'geometry' => null]],
+            [(object)[
+                "format" => 'default', "constraints" => (object)["enum" => ['{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}']],
+            ], '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c4"}}', self::ERROR],
+        ]);
+    }
 
-    date
-    ('default', date(2019, 1, 1), date(2019, 1, 1)),
-    ('default', '2019-01-01', date(2019, 1, 1)),
-    ('default', '10th Jan 1969', ERROR),
-    ('default', 'invalid', ERROR),
-    ('default', True, ERROR),
-    ('default', '', ERROR),
-    ('any', date(2019, 1, 1), date(2019, 1, 1)),
-    ('any', '2019-01-01', date(2019, 1, 1)),
-    ('any', '10th Jan 1969', date(1969, 1, 10)),
-    ('any', '10th Jan nineteen sixty nine', ERROR),
-    ('any', 'invalid', ERROR),
-    ('any', True, ERROR),
-    ('any', '', ERROR),
-    ('%d/%m/%y', date(2019, 1, 1), date(2019, 1, 1)),
-    ('%d/%m/%y', '21/11/06', date(2006, 11, 21)),
-    ('%y/%m/%d','21/11/06 16:30', ERROR),
-    ('%d/%m/%y','invalid', ERROR),
-    ('%d/%m/%y',True, ERROR),
-    ('%d/%m/%y', '', ERROR),
-    ('invalid','21/11/06 16:30', ERROR),
-    # Deprecated
-    ('fmt:%d/%m/%y', date(2019, 1, 1), date(2019, 1, 1)),
-    ('fmt:%d/%m/%y', '21/11/06', date(2006, 11, 21)),
-    ('fmt:%y/%m/%d','21/11/06 16:30', ERROR),
-    ('fmt:%d/%m/%y','invalid', ERROR),
-    ('fmt:%d/%m/%y',True, ERROR),
-    ('fmt:%d/%m/%y', '', ERROR),
 
-    datetime
-    ('default', datetime(2014, 1, 1, 6), datetime(2014, 1, 1, 6)),
-    ('default', '2014-01-01T06:00:00Z', datetime(2014, 1, 1, 6)),
-    ('default', 'Mon 1st Jan 2014 9 am', ERROR),
-    ('default', 'invalid', ERROR),
-    ('default', True, ERROR),
-    ('default', '', ERROR),
-    ('any', datetime(2014, 1, 1, 6), datetime(2014, 1, 1, 6)),
-    ('any', '10th Jan 1969 9 am', datetime(1969, 1, 10, 9)),
-    ('any', 'invalid', ERROR),
-    ('any', True, ERROR),
-    ('any', '', ERROR),
-    ('%d/%m/%y %H:%M', datetime(2006, 11, 21, 16, 30), datetime(2006, 11, 21, 16, 30)),
-    ('%d/%m/%y %H:%M', '21/11/06 16:30', datetime(2006, 11, 21, 16, 30)),
-    ('%H:%M %d/%m/%y', '21/11/06 16:30', ERROR),
-    ('%d/%m/%y %H:%M', 'invalid', ERROR),
-    ('%d/%m/%y %H:%M', True, ERROR),
-    ('%d/%m/%y %H:%M', '', ERROR),
-    ('invalid', '21/11/06 16:30', ERROR),
-    # Deprecated
-    ('fmt:%d/%m/%y %H:%M', datetime(2006, 11, 21, 16, 30), datetime(2006, 11, 21, 16, 30)),
-    ('fmt:%d/%m/%y %H:%M', '21/11/06 16:30', datetime(2006, 11, 21, 16, 30)),
-    ('fmt:%H:%M %d/%m/%y', '21/11/06 16:30', ERROR),
-    ('fmt:%d/%m/%y %H:%M', 'invalid', ERROR),
-    ('fmt:%d/%m/%y %H:%M', True, ERROR),
-    ('fmt:%d/%m/%y %H:%M', '', ERROR),
+    public function testGeopoint()
+    {
+        $this->assertFieldTestData("geopoint", [
+            ['default',  [180, 90],  self::ERROR],
+            ['default', [180, 90],  self::ERROR],
+            ['default', '180,90',  [180, 90]],
+            ['default', '180, -90',  [180, -90]],
+            ['default', (object)['lon' => 180, 'lat' => 90], self::ERROR],
+            ['default', '181,90', self::ERROR],
+            ['default', '0,91', self::ERROR],
+            ['default', 'string', self::ERROR],
+            ['default', 1, self::ERROR],
+            ['default', '3.14', self::ERROR],
+            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['array',  [180, 90],  [180, 90]],
+            ['array', [180, 90],  [180, 90]],
+            ['array', '[180, -90]',  [180, -90]],
+            ['array', (object)['lon' => 180, 'lat' => 90], self::ERROR],
+            ['array', [181, 90], self::ERROR],
+            ['array', [0, 91], self::ERROR],
+            ['array', '180,90', self::ERROR],
+            ['array', 'string', self::ERROR],
+            ['array', 1, self::ERROR],
+            ['array', '3.14', self::ERROR],
+            ['array', '', self::ERROR],  # missingValues is handled at the schema level,
+            ['object', (object)['lon' => 180, 'lat' => 90],  [180, 90]],
+            ['object', '{"lon":180, "lat":90}',  [180, 90]],
+            ['object', '{"lat":90, "lon":180, "foo": "bar"}',  [180, 90]],
+            ['object', '[180, -90]', self::ERROR],
+            ['object', (object)['lon' => 181, 'lat' => 90], self::ERROR],
+            ['object', (object)['lon' => 180, 'lat' => -91], self::ERROR],
+            ['object', [180, -90], self::ERROR],
+            ['object', '180,90', self::ERROR],
+            ['object', 'string', self::ERROR],
+            ['object', 1, self::ERROR],
+            ['object', '3.14', self::ERROR],
+            ['object', '', self::ERROR],  # missingValues is handled at the schema level,
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)["format" => 'array', "constraints" => (object)["enum" => ['[180, -90]']]], '[180, -90]', [180, -90]],
+            [(object)["format" => 'array', "constraints" => (object)["enum" => ['[180, -90]']]], '[171, -90]', self::ERROR],
+        ]);
+    }
 
-    duration
-    ('default', isodate.Duration(years=1), isodate.Duration(years=1)),
-    ('default', 'P1Y10M3DT5H11M7S',
-         isodate.Duration(years=1, months=10, days=3, hours=5, minutes=11, seconds=7)),
-    ('default', 'P1Y', isodate.Duration(years=1)),
-    ('default', 'P1M', isodate.Duration(months=1)),
-    ('default', 'P1M1Y', ERROR),
-    ('default', 'P-1Y', ERROR),
-    ('default', 'year', ERROR),
-    ('default', True, ERROR),
-    ('default', False, ERROR),
-    ('default', 1, ERROR),
-    ('default', '', ERROR),
-    ('default', [], ERROR),
-    ('default', {}, ERROR),
 
-    geojson
-    ('default',
-        {'properties': {'Ã': 'Ã'}, 'type': 'Feature', 'geometry': None},
-        {'properties': {'Ã': 'Ã'}, 'type': 'Feature', 'geometry': None}),
-    ('default',
-        '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}',
-        {'properties': {'Ã': 'Ã'}, 'type': 'Feature', 'geometry': None}),
-    ('default', {'coordinates': [0, 0, 0], 'type': 'Point'}, ERROR),
-    ('default', 'string', ERROR),
-    ('default', 1, ERROR),
-    ('default', '3.14', ERROR),
-    ('default', '', ERROR),
-    ('default', {}, ERROR),
-    ('default', '{}', ERROR),
-    ('topojson',
-        {'type': 'LineString', 'arcs': [42]},
-        {'type': 'LineString', 'arcs': [42]}),
-    ('topojson',
-        '{"type": "LineString", "arcs": [42]}',
-        {'type': 'LineString', 'arcs': [42]}),
-    ('topojson', 'string', ERROR),
-    ('topojson', 1, ERROR),
-    ('topojson', '3.14', ERROR),
-    ('topojson', '', ERROR),
 
-    geopoint
-    ('default', (180, 90), (180, 90)),
-    ('default', [180, 90], (180, 90)),
-    ('default', '180,90', (180, 90)),
-    ('default', '180, -90', (180, -90)),
-    ('default', {'lon': 180, 'lat': 90}, ERROR),
-    ('default', '181,90', ERROR),
-    ('default', '0,91', ERROR),
-    ('default', 'string', ERROR),
-    ('default', 1, ERROR),
-    ('default', '3.14', ERROR),
-    ('default', '', ERROR),
-    ('array', (180, 90), (180, 90)),
-    ('array', [180, 90], (180, 90)),
-    ('array', '[180, -90]', (180, -90)),
-    ('array', {'lon': 180, 'lat': 90}, ERROR),
-    ('array', [181, 90], ERROR),
-    ('array', [0, 91], ERROR),
-    ('array', '180,90', ERROR),
-    ('array', 'string', ERROR),
-    ('array', 1, ERROR),
-    ('array', '3.14', ERROR),
-    ('array', '', ERROR),
-    ('object', {'lon': 180, 'lat': 90}, (180, 90)),
-    ('object', '{"lon": 180, "lat": 90}', (180, 90)),
-    ('object', '[180, -90]', ERROR),
-    ('object', {'lon': 181, 'lat': 90}, ERROR),
-    ('object', {'lon': 180, 'lat': -91}, ERROR),
-    ('object', [180, -90], ERROR),
-    ('object', '180,90', ERROR),
-    ('object', 'string', ERROR),
-    ('object', 1, ERROR),
-    ('object', '3.14', ERROR),
-    ('object', '', ERROR),
+    public function testInteger()
+    {
+        $this->assertFieldTestData("integer", [
+            ['default', 1, 1],
+            ['default', '1', 1],
+            ['default', '3.14', self::ERROR],
+            ['default', "", self::ERROR],  # missingValues is handled at the schema level,
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)["format" => 'default', "constraints" => (object)["enum" => [0, "1"]]], "0", 0],
+            [(object)["format" => 'default', "constraints" => (object)["enum" => [0, "1"]]], "2", self::ERROR],
+        ]);
+    }
 
-    integer
-    ('default', 1, 1),
-    ('default', '1', 1),
-    ('default', '3.14', ERROR),
-    ('default', '', ERROR),
+    public function testNumber()
+    {
+        $this->assertFieldTestData("number", [
+            [(object)["format"=>"default"], 1, 1.0],
+            [(object)["format"=>"default"], 1, 1.0],
+            [(object)["format"=>"default"], 1.0, 1.0],
+            [(object)["format"=>"default"], '1', 1.0],
+            [(object)["format"=>"default"], '10.00', 10.0],
+            [(object)["format"=>"default"], '10.50', 10.5],
+            [(object)["format"=>"default"], '100%', 1.0],
+            [(object)["format"=>"default"], '1000‰', self::ERROR],  # spec only supports percent sign
+            [(object)["format"=>"default"], '-1000', -1000.0],
+            [(object)["format"=>"default", 'groupChar' => ','], '1,000', 1000.0],
+            [(object)["format"=>"default", 'groupChar' => ','], '10,000.00', 10000.0],
+            [(object)["format"=>"default", 'groupChar' => ','], '10,000,000.50', 10000000.5],
+            [(object)["format"=>"default", 'groupChar' => '#'], '10#000.00', 10000.0],
+            [(object)["format"=>"default", 'groupChar' => '#'], '10#000#000.50', 10000000.5],
+            [(object)["format"=>"default", 'groupChar' => '#'], '10.50', 10.5],
+            [(object)["format"=>"default", 'groupChar' => '#'], '1#000', 1000.0],
+            [(object)["format"=>"default", 'groupChar' => '#', "decimalChar" => "@"], '10#000@00', 10000.0],
+            [(object)["format"=>"default", 'groupChar' => '#', "decimalChar" => "@"], '10#000#000@50', 10000000.5],
+            [(object)["format"=>"default", 'groupChar' => '#', "decimalChar" => "@"], '10@50', 10.5],
+            [(object)["format"=>"default", 'groupChar' => '#', "decimalChar" => "@"], '1#000', 1000.0],
+            [(object)["format"=>"default", 'groupChar' => ',', "currency" => true], '10,000.00', 10000.0],
+            [(object)["format"=>"default", 'groupChar' => ',', "currency" => true], '10,000,000.00', 10000000.0],
+            [(object)["format"=>"default", "currency" => true], '$10000.00', 10000.0],
+            [(object)["format"=>"default", 'groupChar' => ',', "currency" => true], '  10,000.00 €', 10000.0],
+            [(object)["format"=>"default", 'groupChar' => ' ', "decimalChar" => ","], '10 000,00', 10000.0],
+            [(object)["format"=>"default", 'groupChar' => ' ', "decimalChar" => ","], '10 000 000,00', 10000000.0],
+            [(object)["format"=>"default", 'groupChar' => ' ', "decimalChar" => ",", "currency" => true], '10000,00 ₪', 10000.0],
+            [(object)["format"=>"default", 'groupChar' => ' ', "decimalChar" => ",", "currency" => true], '  10 000,00 £', 10000.0],
+            [(object)["format"=>"default"], '10,000a.00', self::ERROR],
+            [(object)["format"=>"default"], '10+000.00', self::ERROR],
+            [(object)["format"=>"default"], '$10:000.00', self::ERROR],
+            [(object)["format"=>"default"], 'string', self::ERROR],
+            [(object)["format"=>"default"], '', self::ERROR],  # missingValues is handled at the schema level,
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)["format" => 'default', "constraints" => (object)["enum" => [0.5, "1.6"]]], "1.6", 1.6],
+            [(object)["format" => 'default', "constraints" => (object)["enum" => [0.5, "1.6"]]], "0.55", self::ERROR],
+        ]);
+    }
 
-    number
-    ('default', Decimal(1), {}, Decimal(1)),
-    ('default', 1, {}, Decimal(1)),
-    ('default', 1.0, {}, Decimal(1)),
-    ('default', '1', {}, Decimal(1)),
-    ('default', '10.00', {}, Decimal(10)),
-    ('default', '10.50', {}, Decimal(10.5)),
-    ('default', '100%', {}, Decimal(1)),
-    ('default', '1000‰', {}, Decimal(10)),
-    ('default', '-1000', {}, Decimal(-1000)),
-    ('default', '1,000', {'groupChar': ','}, Decimal(1000)),
-    ('default', '10,000.00', {'groupChar': ','}, Decimal(10000)),
-    ('default', '10,000,000.50', {'groupChar': ','}, Decimal(10000000.5)),
-    ('default', '10#000.00', {'groupChar': '#'}, Decimal(10000)),
-    ('default', '10#000#000.50', {'groupChar': '#'}, Decimal(10000000.5)),
-    ('default', '10.50', {'groupChar': '#'}, Decimal(10.5)),
-    ('default', '1#000', {'groupChar': '#'}, Decimal(1000)),
-    ('default', '10#000@00', {'groupChar': '#', 'decimalChar': '@'}, Decimal(10000)),
-    ('default', '10#000#000@50', {'groupChar': '#', 'decimalChar': '@'}, Decimal(10000000.5)),
-    ('default', '10@50', {'groupChar': '#', 'decimalChar': '@'}, Decimal(10.5)),
-    ('default', '1#000', {'groupChar': '#', 'decimalChar': '@'}, Decimal(1000)),
-    ('default', '10,000.00', {'groupChar': ',', 'currency': True}, Decimal(10000)),
-    ('default', '10,000,000.00', {'groupChar': ',', 'currency': True}, Decimal(10000000)),
-    ('default', '$10000.00', {'currency': True}, Decimal(10000)),
-    ('default', '  10,000.00 €', {'groupChar': ',', 'currency': True}, Decimal(10000)),
-    ('default', '10 000,00', {'groupChar': ' ', 'decimalChar': ','}, Decimal(10000)),
-    ('default', '10 000 000,00', {'groupChar': ' ', 'decimalChar': ','}, Decimal(10000000)),
-    ('default', '10000,00 ₪', {'groupChar': ' ', 'decimalChar': ',', 'currency': True}, Decimal(10000)),
-    ('default', '  10 000,00 £', {'groupChar': ' ', 'decimalChar': ',', 'currency': True}, Decimal(10000)),
-    ('default', '10,000a.00', {}, ERROR),
-    ('default', '10+000.00', {}, ERROR),
-    ('default', '$10:000.00', {}, ERROR),
-    ('default', 'string', {}, ERROR),
-    ('default', '', {}, ERROR),
+    public function testObject()
+    {
+        $this->assertFieldTestData("object", [
+            ['default', (object)[], (object)[]],
+            ['default', '{}', (object)[]],
+            ['default', (object)['key' => 'value'], (object)['key' => 'value']],
+            ['default', '{"key": "value"}', (object)['key' => 'value']],
+            ['default', '["key", "value"]', self::ERROR],
+            ['default', 'string', self::ERROR],
+            ['default', 1, self::ERROR],
+            ['default', '3.14', self::ERROR],
+            ['default', '', self::ERROR],  # missingValues is handled at the schema level,
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)["format" => 'default', "constraints" => (object)["enum" => ['{"foo":"bar"}']]], '{"foo":"bar"}', (object)['foo' => 'bar']],
+            [(object)["format" => 'default', "constraints" => (object)["enum" => ['{"foo":"bar"}']]], '{"foox":"bar"}', self::ERROR],
+        ]);
+    }
 
-    object
-    ('default', {}, {}),
-    ('default', '{}', {}),
-    ('default', {'key': 'value'}, {'key': 'value'}),
-    ('default', '{"key": "value"}', {'key': 'value'}),
-    ('default', '["key", "value"]', ERROR),
-    ('default', 'string', ERROR),
-    ('default', 1, ERROR),
-    ('default', '3.14', ERROR),
-    ('default', '', ERROR),
-
-     */
     public function testString()
     {
         $this->assertFieldTestData('string', [
@@ -258,6 +407,12 @@ class FieldTypesTest extends TestCase
             ['email', 0, self::ERROR],
             ['binary', 'dGVzdA==', 'dGVzdA=='],
             ['binary', '', ''],
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], '', ''],
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)["format" => 'default', "constraints" => (object)["enum" => ['foobar']]], 'foobar', 'foobar'],
+            [(object)["format" => 'default', "constraints" => (object)["enum" => ['foobar']]], 'foobarx', self::ERROR],
         ]);
     }
 
@@ -270,20 +425,19 @@ class FieldTypesTest extends TestCase
             ['default', '3.00', self::ERROR],
             ['default', 'invalid', self::ERROR],
             ['default', true, self::ERROR],
-            ['default', '', null],
+            ['default', '', self::ERROR],
             ['any', '06:00:00', [6, 0, 0]],
             ['any', '3:00 am', [3, 0, 0]],
             ['any', 'some night', self::ERROR],
             ['any', 'invalid', self::ERROR],
             ['any', true, self::ERROR],
-            ['any', '', null],
             ['%H:%M', '06:00', [6, 0, 0]],
             ['%H:%M', '3:00 am', self::ERROR],
             ['%H:%M', 'some night', self::ERROR],
             ['%H:%M', 'invalid', self::ERROR],
             ['%H:%M', true, self::ERROR],
-            ['%H:%M', '', null],
-            ['invalid', '', null],
+            ['%H:%M', '', self::ERROR],
+            ['invalid', '', self::ERROR],
             ['default', '06:35:21', [6, 35, 21]],
             ['any', '06:35:21', [6, 35, 21]],
             ['any', '06:35', [6, 35, 0]],
@@ -291,6 +445,11 @@ class FieldTypesTest extends TestCase
             ['any', '3 am', [3, 0, 0]],
             ['%H:%M:%S', '06:35:21', [6, 35, 21]],
             ['%H:%M', '06:35:21', self::ERROR],
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)["format" => 'default', "constraints" => (object)["enum" => ['06:00:00']]], '06:00:00', [6, 0, 0]],
+            [(object)["format" => 'default', "constraints" => (object)["enum" => ['06:00:00']]], '06:01:00', self::ERROR],
         ]);
     }
 
@@ -302,7 +461,11 @@ class FieldTypesTest extends TestCase
             ['default', '2000', 2000],
             ['default', 20000, 20000],
             ['default', '3.14', self::ERROR],
-            ['default', '', null],
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)["format" => 'default', "constraints" => (object)["enum" => [2000]]], '2000', 2000],
+            [(object)["format" => 'default', "constraints" => (object)["enum" => [2000]]], '2001', self::ERROR],
         ]);
     }
 
@@ -321,7 +484,12 @@ class FieldTypesTest extends TestCase
             ['default', -10, self::ERROR],
             ['default', 20, self::ERROR],
             ['default', '3.14', self::ERROR],
-            ['default', '', null],
+            ['default', '', self::ERROR],
+            // required
+            [(object)["format" => 'default', "constraints" => (object)["required" => true]], null, self::ERROR],
+            // enum
+            [(object)["format" => 'default', "constraints" => (object)["enum" => [[2000, 10]]]], '2000-10', [2000, 10]],
+            [(object)["format" => 'default', "constraints" => (object)["enum" => [[2000, 10]]]], '2000-11', self::ERROR],
         ]);
     }
 
@@ -332,10 +500,21 @@ class FieldTypesTest extends TestCase
                 $testLine[3] = null;
             }
             list($format, $inputValue, $expectedCastValue, $expectedInferType) = $testLine;
-            $assertMessage = "format='{$format}', input='".json_encode($inputValue)."', expected='".json_encode($expectedCastValue)."'";
-            $field = FieldsFactory::field((object) ['type' => $fieldType, 'format' => $format]);
-            if ($expectedCastValue == self::ERROR) {
+            if (is_object($format)) {
+                $descriptor = $format;
+                $descriptor->type = $fieldType;
+            } else {
+                $descriptor = (object) ['type' => $fieldType, 'format' => $format];
+            }
+            $assertMessage = "descriptor=".json_encode($descriptor).", input='".json_encode($inputValue)."', expected='".json_encode($expectedCastValue)."'";
+            if (!isset($descriptor->name)) {
+                $descriptor->name = "unknown";
+            }
+            $field = FieldsFactory::field($descriptor);
+            if ($expectedCastValue === self::ERROR) {
                 $this->assertTrue(count($field->validateValue($inputValue)) > 0, $assertMessage);
+            } elseif (is_object($expectedCastValue)) {
+                $this->assertEquals($expectedCastValue, $field->castValue($inputValue), $assertMessage);
             } else {
                 $this->assertSame($expectedCastValue, $field->castValue($inputValue), $assertMessage);
             }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -221,7 +221,7 @@ class SchemaTest extends TestCase
             ],
         ]);
         $this->assertEquals(
-            'id: value must be numeric (foobar), email: value is not a valid email (bad.email)',
+            'id: value must be numeric ("foobar"), email: value is not a valid email ("bad.email")',
             SchemaValidationError::getErrorMessages(
                 $schema->validateRow(['id' => 'foobar', 'email' => 'bad.email'])
             )
@@ -344,7 +344,7 @@ class SchemaTest extends TestCase
     public function testCastRowWrongType()
     {
         $this->assertCastRowException(
-            'height: value must be numeric (notdecimal)',
+            'height: value must be numeric ("notdecimal")',
             $this->maxDescriptorJson,
             ['id' => 'string', 'height' => 'notdecimal', 'age' => '1', 'name' => 'string', 'additional' => 'string']
         );
@@ -353,7 +353,7 @@ class SchemaTest extends TestCase
     public function testCastRowWrongTypeMultipleErrors()
     {
         $this->assertCastRowException(
-            'height: value must be numeric (notdecimal), age: value must be an integer (10.6)',
+            'height: value must be numeric ("notdecimal"), age: value must be an integer ("10.6")',
             $this->maxDescriptorJson,
             ['id' => 'string', 'height' => 'notdecimal', 'age' => '10.6', 'name' => 'string', 'additional' => 'string']
         );

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -94,7 +94,7 @@ class TableTest extends TestCase
 
     public function testInferSchemaFailsAfterLock()
     {
-        $this->assertInferSchemaException('id: value must be an integer (3.5)', [
+        $this->assertInferSchemaException('id: value must be an integer ("3.5")', [
             ['id' => '1', 'email' => 'test1_example_com'],
             ['id' => '2', 'email' => 'test2@example.com'],
             ['id' => '3.5', 'email' => 'test3@example.com'],
@@ -127,7 +127,7 @@ class TableTest extends TestCase
         ];
         $this->assertInferSchemaException(
             // lock after 1 row, so that locked schema will be string with email format
-            'email: value is not a valid email (invalid_email)', $inputRows, 1
+            'email: value is not a valid email ("invalid_email")', $inputRows, 1
         );
         // try again with locking after 2nd row - no exception
         // (value is not cast, because it's still a string)


### PR DESCRIPTION
fixes #15 

- added all tableschema fields
- cast functionality works for all latest spec features
- require and enum constraints works for all field types
- copied tests from tableschema-py (modified for latest specs)