### PR TITLE
Reset resource file pointer before save

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -148,6 +148,7 @@ class Table implements \Iterator
 
     public function save($outputDataSource)
     {
+        $this->dataSource->open();
         return $this->dataSource->save($outputDataSource);
     }
 


### PR DESCRIPTION
Using functions that move the file pointer will result in saving an incomplete data set unless first reset.

An example is using the read() function with cast:false before saving. The read() function already runs dataSource->open() on line [119](https://github.com/frictionlessdata/tableschema-php/blob/414d60d5ffaec40247b6ad723cfef07e5dcf2e29/src/Table.php#L119), but save() is missing this action.

    $table->read(["cast" => false]));
    // Will only write header row to file
    $table->save('out.csv');

