### PR TITLE
Upgrade Carbon to version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 php:
   - '7.1'
   - '7.2'
-  - nightly
+  - '7.3'
 before_script:
   - COMPOSER_DISABLE_XDEBUG_WARN=1 composer install --prefer-dist
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
+  - '7.2'
   - nightly
 before_script:
   - COMPOSER_DISABLE_XDEBUG_WARN=1 composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,16 @@
     "description": "A utility library for working with Table Schema",
     "license": "MIT",
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "justinrainbow/json-schema": "^5.2",
-        "nesbot/carbon": "^1.22",
+        "nesbot/carbon": "^2.0.0",
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35",
         "satooshi/php-coveralls": "^1.0",
-        "psy/psysh": "@stable"
+        "composer/composer": "^1.9",
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35",
-        "satooshi/php-coveralls": "^1.0",
+        "phpunit/phpunit": "^7.0.0",
         "composer/composer": "^1.9",
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-master",
+        "php-coveralls/php-coveralls": "^2.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0.0",
-        "composer/composer": "^1.9",
         "roave/security-advisories": "dev-master",
         "php-coveralls/php-coveralls": "^2.0.0"
     },

--- a/src/Fields/DateField.php
+++ b/src/Fields/DateField.php
@@ -6,7 +6,7 @@ use Carbon\Carbon;
 
 class DateField extends BaseField
 {
-    protected const DEFAULT_PATTERN = '%Y-%m-%d';
+    protected const DEFAULT_FORMAT = '%Y-%m-%d';
 
     protected function validateCastValue($val)
     {
@@ -20,7 +20,7 @@ class DateField extends BaseField
                 throw $this->getValidationException($e->getMessage(), $val);
             }
         } else {
-            $format = $this->format() === 'default' ? self::DEFAULT_PATTERN : $this->format();
+            $format = $this->format() === 'default' ? self::DEFAULT_FORMAT : $this->format();
             $date = strptime($val, $format);
 
             if ($date === false || $date['unparsed'] != '') {

--- a/src/Fields/DateField.php
+++ b/src/Fields/DateField.php
@@ -27,7 +27,7 @@ class DateField extends BaseField
                 throw $this->getValidationException("couldn't parse date/time according to given strptime format '{$format}''", $val);
             } else {
                 return Carbon::create(
-                    (int)$date['tm_year'] + 1900, (int)$date['tm_mon'] + 1, (int)$date['tm_mday'],
+                    (int) $date['tm_year'] + 1900, (int) $date['tm_mon'] + 1, (int) $date['tm_mday'],
                     0, 0, 0
                 );
             }


### PR DESCRIPTION
This PR upgrades `nesbot/carbon` to version 2.

This is prompted by a nag that carbon injects into composer output to inform that version 1 is no longer supported.

I have set PHP 7.1 as the new minimum version for this package because this is the minimum version supported by Carbon v2

Between Carbon v1 and v2, there was one compatibility breakage identified by the existing tests, which prompted the change to `DateField::validateCastValue()`.  I believe, In version 1 Carbon::create() would raise an exception if supplied a non-integer for the `$year` argument, where in version 2 is detects a string and uses it as a date string rather than a year number.  So the logic changed to force validation for the "default" date format, rather than depend on Carbon to raise an exception.

I have also raised the version of PHPUnit from version 4 to 7. No code changes were required.