### PR TITLE
Allow for no conversion to null when missingValue property is an empty array

### DIFF
--- a/src/schemas/table-schema.json
+++ b/src/schemas/table-schema.json
@@ -1540,7 +1540,6 @@
     },
     "missingValues": {
       "type": "array",
-      "minItems": 1,
       "items": {
         "type": "string"
       },

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -134,7 +134,19 @@ class FieldTest extends TestCase
             ],
             'missingValues' => ['null'],
         ]);
-        $this->assertEquals(['name' => null], $schema->castRow(['name' => 'null']));
+        $this->assertSame(['name' => null], $schema->castRow(['name' => 'null']));
+    }
+
+    public function testDoNotCastValueNullMissingValues()
+    {
+        // missing values are only validated at schema castRow function
+        $schema = new Schema((object) [
+            'fields' => [
+                ['name' => 'name', 'type' => 'string'],
+            ],
+            'missingValues' => [],
+        ]);
+        $this->assertSame(['name' => ''], $schema->castRow(['name' => '']));
     }
 
     public function testValidateValue()
@@ -334,7 +346,7 @@ class FieldTest extends TestCase
             'missingValues' => $missingValues,
         ]);
         foreach ($missingValues as $val) {
-            $this->assertEquals(['name' => null], $schema->castRow(['name' => $val]));
+            $this->assertSame(['name' => null], $schema->castRow(['name' => $val]));
         }
     }
 }


### PR DESCRIPTION
# Overview

I understand that which values are converted to `null` is determined by the `missingValues` property.  By default this is, `"missingValues": [""]` (I.e. convert empty string to `null`.)

The specification describes the following to preserve the value.

> Providing the empty list `[]` means that no conversion to null will be done, on any value.

This PR makes changes for this to work as expected -- which is basically just a change JSON schema and adding some tests.

---

Please preserve this line to notify @OriHoch (lead of this repository)
