### PR TITLE
#49 Update development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,16 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
+        "ext-mbstring": "*",
         "justinrainbow/json-schema": "^5.2",
         "nesbot/carbon": "^2.0.0",
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35",
-        "satooshi/php-coveralls": "^1.0",
-        "psy/psysh": "@stable"
+        "phpunit/phpunit": "^7.0",
+        "php-coveralls/php-coveralls": "^2.4",
+        "psy/psysh": "@stable",
+        "roave/security-advisories": "dev-latest"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
**Issue:** #49 

* Updates version requirement for `phpunit/phpunit` to `^7.0`.
* Replaces `satooshi/php-coveralls` with `php-coveralls/php-coveralls`.
* Add `roave/security-advisories` for a little extra safety in development environments.
