### PR TITLE
Change GH action name to "tests" and update badge in README.md

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 on:
     push:
         branches: [ main ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tableschema-php
 
-[![Travis](https://travis-ci.org/frictionlessdata/tableschema-php.svg?branch=master)](https://travis-ci.org/frictionlessdata/tableschema-php)
+[![Tests](https://github.com/frictionlessdata/tableschema-php/actions/workflows/tests.yml/badge.svg)](https://github.com/frictionlessdata/tableschema-php/actions/workflows/tests.yml)
 [![Coveralls](http://img.shields.io/coveralls/frictionlessdata/tableschema-php.svg?branch=master)](https://coveralls.io/r/frictionlessdata/tableschema-php?branch=master)
 [![Scrutinizer-ci](https://scrutinizer-ci.com/g/OriHoch/tableschema-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/OriHoch/tableschema-php/)
 [![Packagist](https://img.shields.io/packagist/dm/frictionlessdata/tableschema.svg)](https://packagist.org/packages/frictionlessdata/tableschema)


### PR DESCRIPTION
This PR changes the name of the GH action for running test from "ci" to "tests" and replaces the Travis bad in README.md.

The name of the action is displayed in the badge image, so we needed it to be something a little more meaningful than "CI".