### PR TITLE
Add constraint enforcement for primary key

### DIFF
--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -7,6 +7,7 @@ namespace frictionlessdata\tableschema\tests;
 use Carbon\Carbon;
 use frictionlessdata\tableschema\DataSources\CsvDataSource;
 use frictionlessdata\tableschema\DataSources\NativeDataSource;
+use frictionlessdata\tableschema\Exceptions\DataSourceException;
 use frictionlessdata\tableschema\Exceptions\FieldValidationException;
 use frictionlessdata\tableschema\InferSchema;
 use frictionlessdata\tableschema\Schema;
@@ -130,6 +131,109 @@ class TableTest extends TestCase
             ['first_name' => 'Baz', 'last_name' => 'Bax', 'order' => 2],
             ['first_name' => 'באך', 'last_name' => 'ביי', 'order' => 3],
         ], $table->read());
+    }
+
+    /**
+     * @dataProvider provideDuplicatePrimaryKeyTestData
+     *
+     * @param string|array|stdClass $descriptor
+     */
+    public function testEnforcePrimaryKey(string $expectedExceptionMessage, $descriptor, array $duplicateRows): void
+    {
+        $this->expectException(DataSourceException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $tableData = new NativeDataSource($duplicateRows);
+        $schema = new Schema($descriptor);
+        $table = new Table($tableData, $schema);
+
+        // Traverse all the rows.
+        iterator_to_array($table);
+    }
+
+    public function provideDuplicatePrimaryKeyTestData(): \Generator
+    {
+        yield 'Null value not allowed for field in Primary Key' => [
+            'row 1: value for id field cannot be null because it is part of the primary key',
+            <<<JSON
+{
+"fields": [ {"name": "id"} ],
+"primaryKey": ["id"]
+}
+JSON,
+            [['id' => '']],
+        ];
+
+        yield 'Missing value not allowed for field in Primary Key' => [
+            'row 1: value for id field cannot be null because it is part of the primary key',
+            <<<JSON
+{
+    "fields": [ {"name": "id"} ],
+    "primaryKey": ["id"],
+    "missingValues": ["n/a"]
+}
+JSON,
+            [['id' => 'n/a']],
+        ];
+
+        yield 'Duplicate row on single primary key for single field' => [
+            'row 2: duplicate row for the primary key id',
+            <<<JSON
+{
+    "fields": [ {"name": "id"} ],
+    "primaryKey": ["id"]
+}
+JSON,
+            [
+                ['id' => 'foo'],
+                ['id' => 'foo'],
+            ],
+        ];
+
+        yield 'Duplicate row on primary key for multiple fields' => [
+            'row 3: duplicate row for the primary key id/age',
+            <<<JSON
+{
+    "fields": [ {"name": "id"}, {"name": "age"} ],
+    "primaryKey": [ "id", "age" ]
+}
+JSON,
+            [
+                ['id' => 'foo', 'age' => '123'],
+                ['id' => 'foo', 'age' => '234'],
+                ['id' => 'foo', 'age' => '123'],
+            ],
+        ];
+
+        yield 'Duplicate row on primary key for datetime object' => [
+            'row 3: duplicate row for the primary key date',
+            <<<JSON
+{
+    "fields": [ {"name": "date", "type": "date"} ],
+    "primaryKey": [ "date" ]
+}
+JSON,
+            [
+                ['date' => '2022-01-16'],
+                ['date' => '2022-01-10'],
+                ['date' => '2022-01-16'],
+            ],
+        ];
+
+        yield 'Duplicate row on primary key with type-insensitivity' => [
+            'row 3: duplicate row for the primary key id',
+            <<<JSON
+{
+    "fields": [ {"name": "id", "type": "integer"} ],
+    "primaryKey": [ "id" ]
+}
+JSON,
+            [
+                ['id' => '123'],
+                ['id' => 234],
+                ['id' => 123],
+            ],
+        ];
     }
 
     public function testTableSave(): void

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -160,7 +160,8 @@ class TableTest extends TestCase
 "fields": [ {"name": "id"} ],
 "primaryKey": ["id"]
 }
-JSON,
+JSON
+            ,
             [['id' => '']],
         ];
 
@@ -172,7 +173,8 @@ JSON,
     "primaryKey": ["id"],
     "missingValues": ["n/a"]
 }
-JSON,
+JSON
+            ,
             [['id' => 'n/a']],
         ];
 
@@ -183,7 +185,8 @@ JSON,
     "fields": [ {"name": "id"} ],
     "primaryKey": ["id"]
 }
-JSON,
+JSON
+            ,
             [
                 ['id' => 'foo'],
                 ['id' => 'foo'],
@@ -197,7 +200,8 @@ JSON,
     "fields": [ {"name": "id"}, {"name": "age"} ],
     "primaryKey": [ "id", "age" ]
 }
-JSON,
+JSON
+            ,
             [
                 ['id' => 'foo', 'age' => '123'],
                 ['id' => 'foo', 'age' => '234'],
@@ -212,7 +216,8 @@ JSON,
     "fields": [ {"name": "date", "type": "date"} ],
     "primaryKey": [ "date" ]
 }
-JSON,
+JSON
+            ,
             [
                 ['date' => '2022-01-16'],
                 ['date' => '2022-01-10'],
@@ -227,7 +232,8 @@ JSON,
     "fields": [ {"name": "id", "type": "integer"} ],
     "primaryKey": [ "id" ]
 }
-JSON,
+JSON
+            ,
             [
                 ['id' => '123'],
                 ['id' => 234],


### PR DESCRIPTION
* **Issue:** #64 
* **What:**
  * Throw an exception if table contains a row with a duplicate primary key.
  * Throw an exception if a field is a part of the primary key and has a null value.
* **Why:** To conform with the specification at [Table Schema: Primary Key](https://specs.frictionlessdata.io/table-schema/#primary-key)