### PR TITLE
Set and test lowest compatible dependency versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-php-
             - name: Install dependencies
-              run: composer install ${{ matrix.composer-prefer }} --no-progress
+              run: composer update ${{ matrix.composer-prefer }} --no-progress
 
             - name: Run Code Style Check for PHP ${{ matrix.php-version }}
               run: composer run-script style-check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,11 @@ jobs:
         strategy:
             matrix:
                 php-version: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                composer-prefer:
+                    - '--prefer-dist'
+                    - '--prefer-stable --prefer-lowest'
 
-        name: frictionlessdata/tableschema-php PHP ${{ matrix.php-version }} test
+        name: Test PHP ${{ matrix.php-version }} / composer ${{matrix.composer-prefer}}
 
         steps:
             - uses: actions/checkout@v2
@@ -36,7 +39,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-php-
             - name: Install dependencies
-              run: composer install --prefer-dist --no-progress
+              run: composer install ${{ matrix.composer-prefer }} --no-progress
 
             - name: Run Code Style Check for PHP ${{ matrix.php-version }}
               run: composer run-script style-check

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
         "php": ">=7.1.0",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "justinrainbow/json-schema": "^5.2",
-        "nesbot/carbon": "^2.0.0",
+        "justinrainbow/json-schema": "^5.2.10",
+        "nesbot/carbon": "^2.23.0",
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=7.0",
+        "phpunit/phpunit": ">=7.5",
         "php-coveralls/php-coveralls": "^2.4",
         "psy/psysh": "@stable",
         "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
* **Issue:** #68
* **What:** Updates the lowest compatible version for each dependency and adds tests to ensure compatibility
* **Why:** Early versions of a few dependencies will cause errors, especially with different versions of PHP that they are otherwise indicated to be compatible with.