### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-version: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php-version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
                 composer-prefer:
                     - '--prefer-dist'
                     - '--prefer-stable --prefer-lowest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,9 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-php-
             - name: Install dependencies
-              run: composer update ${{ matrix.composer-prefer }} --no-progress
+              run: |
+                  composer update ${{ matrix.composer-prefer }} --no-progress
+                  composer update phpunit/phpunit --no-progress
 
             - name: Run Code Style Check for PHP ${{ matrix.php-version }}
               run: composer run-script style-check

--- a/.install-cs-fixer.sh
+++ b/.install-cs-fixer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 if [ ! -f ./php-cs-fixer ]; then
-    wget https://cs.symfony.com/download/php-cs-fixer-v3.phar -O php-cs-fixer
+    wget https://cs.symfony.com/download/v3.4.0/php-cs-fixer.phar -O php-cs-fixer
     chmod +x php-cs-fixer
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:8.0-cli
+FROM php:8.1-cli
 
-RUN apt-get update
+RUN apt-get update -y
 
 ## PHP dependencies
 RUN pecl install xdebug \

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=7.5",
+        "phpunit/phpunit": ">=7.5 <10.0",
         "php-coveralls/php-coveralls": "^2.4",
         "psy/psysh": "@stable",
         "roave/security-advisories": "dev-latest"

--- a/src/Fields/BaseField.php
+++ b/src/Fields/BaseField.php
@@ -7,6 +7,9 @@ use frictionlessdata\tableschema\SchemaValidationError;
 
 abstract class BaseField
 {
+    /**
+     * @param object $descriptor
+     */
     public function __construct($descriptor = null)
     {
         $this->descriptor = empty($descriptor) ? (object) [] : $descriptor;

--- a/src/Fields/DateField.php
+++ b/src/Fields/DateField.php
@@ -3,6 +3,7 @@
 namespace frictionlessdata\tableschema\Fields;
 
 use Carbon\Carbon;
+use frictionlessdata\tableschema\Utility\StrptimeFormatTransformer;
 
 class DateField extends BaseField
 {
@@ -21,13 +22,13 @@ class DateField extends BaseField
             }
         } else {
             $format = 'default' === $this->format() ? self::DEFAULT_FORMAT : $this->format();
-            $date = strptime($val, $format);
+            $date = date_parse_from_format(StrptimeFormatTransformer::transform($format), $val);
 
-            if (false === $date || '' != $date['unparsed']) {
+            if ($date['error_count'] > 0) {
                 throw $this->getValidationException("couldn't parse date/time according to given strptime format '{$format}''", $val);
             } else {
                 return Carbon::create(
-                    (int) $date['tm_year'] + 1900, (int) $date['tm_mon'] + 1, (int) $date['tm_mday'],
+                    (int) $date['year'], (int) $date['month'], (int) $date['day'],
                     0, 0, 0
                 );
             }

--- a/src/Fields/DatetimeField.php
+++ b/src/Fields/DatetimeField.php
@@ -3,6 +3,7 @@
 namespace frictionlessdata\tableschema\Fields;
 
 use Carbon\Carbon;
+use frictionlessdata\tableschema\Utility\StrptimeFormatTransformer;
 
 class DatetimeField extends BaseField
 {
@@ -33,13 +34,13 @@ class DatetimeField extends BaseField
                     throw $this->getValidationException($e->getMessage(), $val);
                 }
             default:
-                $date = strptime($val, $this->format());
-                if (false === $date || '' != $date['unparsed']) {
+                $date = date_parse_from_format(StrptimeFormatTransformer::transform($this->format()), $val);
+                if ($date['error_count'] > 0) {
                     throw $this->getValidationException("couldn't parse date/time according to given strptime format '{$this->format()}''", $val);
                 } else {
                     return Carbon::create(
-                        (int) $date['tm_year'] + 1900, (int) $date['tm_mon'] + 1, (int) $date['tm_mday'],
-                        (int) $date['tm_hour'], (int) $date['tm_min'], (int) $date['tm_sec']
+                        (int) $date['year'], (int) $date['month'], (int) $date['day'],
+                        (int) $date['hour'], (int) $date['minute'], (int) $date['second']
                     );
                 }
         }

--- a/src/Fields/TimeField.php
+++ b/src/Fields/TimeField.php
@@ -3,6 +3,7 @@
 namespace frictionlessdata\tableschema\Fields;
 
 use Carbon\Carbon;
+use frictionlessdata\tableschema\Utility\StrptimeFormatTransformer;
 
 /**
  * Class TimeField
@@ -32,11 +33,15 @@ class TimeField extends BaseField
 
                 return $this->getNativeTime($dt->hour, $dt->minute, $dt->second);
             default:
-                $date = strptime($val, $this->format());
-                if (false === $date || '' != $date['unparsed']) {
+                $date = date_parse_from_format(
+                    StrptimeFormatTransformer::transform($this->format()),
+                    $val
+                );
+
+                if ($date['error_count'] > 0) {
                     throw $this->getValidationException(null, $val);
                 } else {
-                    return $this->getNativeTime($date['tm_hour'], $date['tm_min'], $date['tm_sec']);
+                    return $this->getNativeTime($date['hour'], $date['minute'], $date['second']);
                 }
         }
     }

--- a/src/Table.php
+++ b/src/Table.php
@@ -160,6 +160,7 @@ class Table implements \Iterator
      * @throws Exceptions\FieldValidationException
      * @throws Exceptions\DataSourceException
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if (count($this->castRows) > 0) {
@@ -213,6 +214,7 @@ class Table implements \Iterator
         $this->dataSource->close();
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         if (0 == $this->currentLine) {
@@ -223,11 +225,13 @@ class Table implements \Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->currentLine - count($this->castRows);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if (0 == count($this->castRows)) {
@@ -235,6 +239,7 @@ class Table implements \Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->castRows) > 0 || !$this->dataSource->isEof();

--- a/src/Utility/StrptimeFormatTransformer.php
+++ b/src/Utility/StrptimeFormatTransformer.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace frictionlessdata\tableschema\Utility;
 
-use DateTimeImmutable;
-
 final class StrptimeFormatTransformer
 {
     public static function transform(string $strptimeFormat): string

--- a/src/Utility/StrptimeFormatTransformer.php
+++ b/src/Utility/StrptimeFormatTransformer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace frictionlessdata\tableschema\Utility;
+
+use DateTimeImmutable;
+
+final class StrptimeFormatTransformer
+{
+    public static function transform(string $strptimeFormat): string
+    {
+        return strtr(
+            $strptimeFormat,
+            [
+                // Day
+                '%d' => 'd', // 09
+                '%e' => 'j', // 9
+
+                // Month
+                '%m' => 'm', // 02
+                '%b' => 'M', // Feb
+                '%B' => 'F', // February
+
+                // Year
+                '%Y' => 'Y', // 2023
+                '%y' => 'y', // 23
+
+                // Hour
+                '%H' => 'H', // 00 to 23
+                '%k' => 'G', // 0 to 23
+                '%I' => 'h', // 00 to 12
+                '%l' => 'h', // 0 to 12
+                '%p' => 'A', // AM / PM
+                '%P' => 'a', // am / pm
+
+                // Minute
+                '%M' => 'i',
+
+                // Second
+                '%S' => 's',
+
+                // Date
+                '%D' => 'm/d/y',
+                '%F' => 'Y-m-d',
+
+                // Time
+                '%r' => 'h:i:s A',
+                '%R' => 'H:i',
+                '%T' => 'H:i:s',
+                '%s' => 'U',
+            ]
+        );
+    }
+}

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -79,7 +79,7 @@ class FieldTest extends TestCase
         );
     }
 
-    public function provideFieldWithType(): array
+    public static function provideFieldWithType(): array
     {
         return [
             [
@@ -104,7 +104,7 @@ class FieldTest extends TestCase
         );
     }
 
-    public function provideFieldDescriptorFormat(): array
+    public static function provideFieldDescriptorFormat(): array
     {
         return [
             [
@@ -129,7 +129,7 @@ class FieldTest extends TestCase
         );
     }
 
-    public function provideFieldConstraintsTestData(): array
+    public static function provideFieldConstraintsTestData(): array
     {
         return [
             [
@@ -158,7 +158,7 @@ class FieldTest extends TestCase
         );
     }
 
-    public function provideFieldRequiredTestData(): array
+    public static function provideFieldRequiredTestData(): array
     {
         return [
             [
@@ -231,7 +231,7 @@ class FieldTest extends TestCase
         );
     }
 
-    public function provideDisableConstraintTestData(): array
+    public static function provideDisableConstraintTestData(): array
     {
         return [
             [
@@ -285,7 +285,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue($expectedError, $fieldDescriptor, $value);
     }
 
-    public function provideValidateValueTestData(): array
+    public static function provideValidateValueTestData(): array
     {
         return [
             [
@@ -321,7 +321,7 @@ class FieldTest extends TestCase
         );
     }
 
-    public function provideValidateValueDisableConstraintsTestData(): array
+    public static function provideValidateValueDisableConstraintsTestData(): array
     {
         return [
             [
@@ -347,7 +347,7 @@ class FieldTest extends TestCase
         $this->assertMissingValues(['type' => $fieldType], ['', 'NA', 'N/A']);
     }
 
-    public function provideMissingDataFieldType(): array
+    public static function provideMissingDataFieldType(): array
     {
         return [
             ['string'],
@@ -427,7 +427,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue('', $descriptor, $validValue);
     }
 
-    public function provideValidDataForConstraint(): array
+    public static function provideValidDataForConstraint(): array
     {
         return [
             ['string', ['pattern' => '3.*'], '3'],
@@ -471,7 +471,7 @@ class FieldTest extends TestCase
         $this->assertFieldValidateValue($expectedError, $descriptor, $invalidValue);
     }
 
-    public function provideInvalidDataForConstraint(): array
+    public static function provideInvalidDataForConstraint(): array
     {
         return [
             ['name: value does not match pattern ("123")', 'string', ['pattern' => '3.*'], '123'],

--- a/tests/Fields/DateFieldTest.php
+++ b/tests/Fields/DateFieldTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace frictionlessdata\tableschema\tests\Fields;
+
+use Carbon\Carbon;
+use DateTime;
+use DateTimeInterface;
+use frictionlessdata\tableschema\Fields\DateField;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \frictionlessdata\tableschema\Fields\DateField
+ */
+class DateFieldTest extends TestCase
+{
+    /**
+     * @dataProvider provideDateFormatTestData
+     */
+    public function testParseDateFormat(DateTimeInterface $expectedDateTime, string $format, $dateValue): void
+    {
+        $descriptor = (object) ['format' => $format];
+        $sut = new DateField($descriptor);
+
+        $castValue = $sut->castValue($dateValue);
+        self::assertInstanceOf(Carbon::class, $castValue);
+
+        self::assertTrue(
+            $castValue->eq($expectedDateTime)
+        );
+    }
+
+    public static function provideDateFormatTestData(): iterable
+    {
+        yield [new DateTime('2023-02-28'), '%Y-%m-%d', '2023-02-28'];
+    }
+}

--- a/tests/Fields/DatetimeFieldTest.php
+++ b/tests/Fields/DatetimeFieldTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace frictionlessdata\tableschema\tests\Fields;
+
+use Carbon\Carbon;
+use DateTime;
+use DateTimeInterface;
+use frictionlessdata\tableschema\Fields\DatetimeField;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \frictionlessdata\tableschema\Fields\DatetimeField
+ */
+class DatetimeFieldTest extends TestCase
+{
+    /**
+     * @dataProvider provideDateFormatTestData
+     */
+    public function testParseDateFormat(DateTimeInterface $expectedDateTime, string $format, $dateValue): void
+    {
+        $descriptor = (object) ['format' => $format];
+        $sut = new DatetimeField($descriptor);
+
+        $castValue = $sut->castValue($dateValue);
+        self::assertInstanceOf(Carbon::class, $castValue);
+
+        self::assertTrue(
+            $castValue->eq($expectedDateTime)
+        );
+    }
+
+    public static function provideDateFormatTestData(): iterable
+    {
+        yield [new DateTime('2023-02-28 13:12:34'), '%Y-%m-%d %H:%M:%S', '2023-02-28 13:12:34'];
+    }
+}

--- a/tests/Fields/TimeFieldTest.php
+++ b/tests/Fields/TimeFieldTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace frictionlessdata\tableschema\tests\Fields;
+
+use frictionlessdata\tableschema\Fields\TimeField;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \frictionlessdata\tableschema\Fields\TimeField
+ */
+class TimeFieldTest extends TestCase
+{
+    /**
+     * @dataProvider provideDateFormatTestData
+     */
+    public function testParseDateFormat(array $expectedTimeParts, string $format, $dateValue): void
+    {
+        $descriptor = (object) ['format' => $format];
+        $sut = new TimeField($descriptor);
+
+        self::assertSame(
+            $expectedTimeParts,
+            $sut->castValue($dateValue)
+        );
+    }
+
+    public static function provideDateFormatTestData(): iterable
+    {
+        yield [[13, 12, 34], '%H:%M:%S', '13:12:34'];
+    }
+}

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -13,6 +13,7 @@ use frictionlessdata\tableschema\InferSchema;
 use frictionlessdata\tableschema\Schema;
 use frictionlessdata\tableschema\SchemaValidationError;
 use frictionlessdata\tableschema\Table;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 class TableTest extends TestCase
@@ -151,7 +152,7 @@ class TableTest extends TestCase
         iterator_to_array($table);
     }
 
-    public function provideDuplicatePrimaryKeyTestData(): \Generator
+    public static function provideDuplicatePrimaryKeyTestData(): Generator
     {
         yield 'Null value not allowed for field in Primary Key' => [
             'row 1: value for id field cannot be null because it is part of the primary key',

--- a/tests/Utility/StrptimeFormatTransformerTestCase.php
+++ b/tests/Utility/StrptimeFormatTransformerTestCase.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utility;
+
+use frictionlessdata\tableschema\Utility\StrptimeFormatTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \frictionlessdata\tableschema\Utility\StrptimeFormatTransformer
+ */
+class StrptimeFormatTransformerTestCase extends TestCase
+{
+    /**
+     * @dataProvider provideStrptimeFormatTestData
+     */
+    public function testStrptimeFormatConversion($dateTimeArr, string $strptimeFormat, string $time): void
+    {
+        $parsedDateTime = date_parse_from_format(
+            StrptimeFormatTransformer::transform($strptimeFormat),
+            $time
+        );
+        self::assertSame(
+            $dateTimeArr,
+            array_intersect_key(
+                $parsedDateTime,
+                array_flip(['year', 'month', 'day', 'hour', 'minute', 'second'])
+            )
+        );
+
+        self::assertEquivalentStrptime(
+            @strptime($time, $strptimeFormat),
+            $parsedDateTime
+        );
+    }
+
+    public static function provideStrptimeFormatTestData(): iterable
+    {
+        // Day
+        yield [
+            ['year' => false, 'month' => false, 'day' => 3, 'hour' => false, 'minute' => false, 'second' => false],
+            '%d',
+            '03',
+        ];
+        yield [
+            ['year' => false, 'month' => false, 'day' => 3, 'hour' => false, 'minute' => false, 'second' => false],
+            '%e',
+            '3',
+        ];
+
+        // Month
+        yield [
+            ['year' => false, 'month' => 2, 'day' => false, 'hour' => false, 'minute' => false, 'second' => false],
+            '%m',
+            '02',
+        ];
+        yield [
+            ['year' => false, 'month' => 2, 'day' => false, 'hour' => false, 'minute' => false, 'second' => false],
+            '%b',
+            'Feb',
+        ];
+        yield [
+            ['year' => false, 'month' => 2, 'day' => false, 'hour' => false, 'minute' => false, 'second' => false],
+            '%B',
+            'February',
+        ];
+
+        // Year
+        yield [
+            ['year' => 2023, 'month' => false, 'day' => false, 'hour' => false, 'minute' => false, 'second' => false],
+            '%Y',
+            '2023',
+        ];
+        yield [
+            ['year' => 2023, 'month' => false, 'day' => false, 'hour' => false, 'minute' => false, 'second' => false],
+            '%y',
+            '23',
+        ];
+
+        // Hour
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 9, 'minute' => 0, 'second' => 0],
+            '%H',
+            '09',
+        ];
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 9, 'minute' => 0, 'second' => 0],
+            '%k',
+            '9',
+        ];
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 23, 'minute' => 0, 'second' => 0],
+            '%I %p',
+            '11 PM',
+        ];
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 13, 'minute' => 0, 'second' => 0],
+            '%l %p',
+            '1 PM',
+        ];
+        // Not understood by strptime
+//        yield [
+//            ['year' => false, 'month' => false, 'day' => false, 'hour' => 13, 'minute' => 0, 'second' => 0],
+//            '%l %P',
+//            '1 pm',
+//        ];
+
+        // Minute
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 0, 'minute' => 9, 'second' => 0],
+            '%M',
+            '09',
+        ];
+
+        // Second
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 0, 'minute' => 0, 'second' => 9],
+            '%S',
+            '09',
+        ];
+
+        // Date
+        yield [
+            ['year' => 2009, 'month' => 2, 'day' => 5, 'hour' => false, 'minute' => false, 'second' => false],
+            '%D',
+            '02/05/09',
+        ];
+        yield [
+            ['year' => 2009, 'month' => 2, 'day' => 5, 'hour' => false, 'minute' => false, 'second' => false],
+            '%F',
+            '2009-02-05',
+        ];
+
+        // Time
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 21, 'minute' => 34, 'second' => 17],
+            '%r',
+            '09:34:17 PM',
+        ];
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 13, 'minute' => 23, 'second' => 0],
+            '%R',
+            '13:23',
+        ];
+        yield [
+            ['year' => false, 'month' => false, 'day' => false, 'hour' => 13, 'minute' => 23, 'second' => 34],
+            '%T',
+            '13:23:34',
+        ];
+        yield [
+            ['year' => 2023, 'month' => 10, 'day' => 27, 'hour' => 4, 'minute' => 32, 'second' => 44],
+            '%s',
+            '1698381164',
+        ];
+    }
+
+    private static function assertEquivalentStrptime(array $strptime, array $actual): void
+    {
+        if (0 === $strptime['tm_year']) {
+            self::assertFalse($actual['year']);
+        } else {
+            self::assertSame($strptime['tm_year'] + 1900, $actual['year']);
+        }
+
+        if (0 === $strptime['tm_mon']) {
+            self::assertFalse($actual['month']);
+        } else {
+            self::assertSame($strptime['tm_mon'] + 1, $actual['month']);
+        }
+
+        if (0 === $strptime['tm_mday']) {
+            self::assertFalse($actual['day']);
+        } else {
+            self::assertSame($strptime['tm_mday'], $actual['day']);
+        }
+    }
+}


### PR DESCRIPTION
# Overview

**Issue:** #70 

Updates package for PHP 8.1 compatibility.

* Implementations of the methods for the `\Iterator` interface have had `#[\ReturnTypeWillChange]` added, since these methods have a return type as a PHP 8.1
* `strptime` has been deprecated.  `StrptimeFormatTransformer` has been introduced to convert a pattern from Python format to the format understood by `date_parse_from_format`. (I.e. `%Y-%m-%d` is changed to `Y-m-d`.)

Dev changes:
* PHP CS Fixer has had it's version fixed to 3.4.0 as this is the last version with compatibility with PHP 7.2.
* PHPUnit is pinned to versions between 7.5 and 10.0.
* Test data provider methods have changed to static for compatibility with the next version of PHPUnit

