### PR TITLE
feat: Update validation error to include original value

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
             - name: Cache Composer packages
               id: composer-cache
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: vendor
                   key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli
+FROM php:8.1-cli
 
 RUN apt-get update -y
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,4 @@ services:
         volumes:
             - .:/src
         command: bash
+        network_mode: host

--- a/src/Fields/BaseField.php
+++ b/src/Fields/BaseField.php
@@ -171,6 +171,12 @@ abstract class BaseField
 
             return [];
         } catch (FieldValidationException $e) {
+            foreach ($e->validationErrors as $ve) {
+                // Replace the cast-value for the violation, with the original value.
+                // This so the error message contains the original representation of the invalid value.
+                $ve->extraDetails['value'] = $val;
+            }
+
             return $e->validationErrors;
         }
     }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -475,12 +475,12 @@ class FieldTest extends TestCase
     {
         return [
             ['name: value does not match pattern ("123")', 'string', ['pattern' => '3.*'], '123'],
-            ['name: value not in enum (4)', 'integer', ['enum' => ['1', '2', 3]], '4'],
+            ['name: value not in enum ("4")', 'integer', ['enum' => ['1', '2', 3]], '4'],
             ['name: value not in enum (4)', 'integer', ['enum' => ['1', '2', 3]], 4],
             ['name: value is below minimum (0)', 'integer', ['minimum' => 1], 0],
-            ['name: value is below minimum (0)', 'integer', ['minimum' => 1], '0'],
+            ['name: value is below minimum ("0")', 'integer', ['minimum' => 1], '0'],
             ['name: value is above maximum (2)', 'integer', ['maximum' => 1], 2],
-            ['name: value is above maximum (2)', 'integer', ['maximum' => 1], '2'],
+            ['name: value is above maximum ("2")', 'integer', ['maximum' => 1], '2'],
             ['name: value is below minimum length ("a")', 'string', ['minLength' => 2], 'a'],
             ['name: value is above maximum length ("aaa")', 'string', ['maxLength' => 2], 'aaa'],
         ];

--- a/tests/Fields/BaseFieldTest.php
+++ b/tests/Fields/BaseFieldTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fields;
+
+use frictionlessdata\tableschema\Fields\BaseField;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \frictionlessdata\tableschema\Fields\BaseField
+ */
+class BaseFieldTest extends TestCase
+{
+    public function testPreserveOriginalValueInValidationError(): void
+    {
+        $descriptor = (object) [
+            'name' => 'date_col',
+            'constraints' => (object) ['minimum' => '2025-07-01'],
+        ];
+
+        $sut = new class($descriptor) extends BaseField {
+            protected function validateCastValue($val)
+            {
+                // If the logic is wrong, this object will be in the error
+                // instead of the original date string.
+                return new \DateTimeImmutable($val);
+            }
+        };
+
+        $validatedValue = '2025-06-30';
+        $errors = $sut->validateValue($validatedValue);
+
+        self::assertCount(1, $errors);
+        $error = reset($errors);
+        self::assertSame(
+            $validatedValue,
+            $error->extraDetails['value']
+        );
+    }
+}


### PR DESCRIPTION
# Overview

This change ensures that a validation error contains the original value being validated, and not the value after it has been cast.

---

Please preserve this line to notify @courtney-miles (lead of this repository)
