### PR TITLE
feat: Update cast exception to include original value

### DIFF
--- a/tests/Fields/BaseFieldTest.php
+++ b/tests/Fields/BaseFieldTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fields;
 
+use frictionlessdata\tableschema\Exceptions\FieldValidationException;
 use frictionlessdata\tableschema\Fields\BaseField;
 use PHPUnit\Framework\TestCase;
 
@@ -12,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BaseFieldTest extends TestCase
 {
-    public function testPreserveOriginalValueInValidationError(): void
+    public function testPreserveOriginalValueInValidateError(): void
     {
         $descriptor = (object) [
             'name' => 'date_col',
@@ -30,6 +31,46 @@ class BaseFieldTest extends TestCase
 
         $validatedValue = '2025-06-30';
         $errors = $sut->validateValue($validatedValue);
+
+        self::assertCount(1, $errors);
+        $error = reset($errors);
+        self::assertSame(
+            $validatedValue,
+            $error->extraDetails['value']
+        );
+    }
+
+    public function testPreserveOriginalValueInCastError(): void
+    {
+        $descriptor = (object) [
+            'name' => 'date_col',
+            'constraints' => (object) ['minimum' => '2025-07-01'],
+        ];
+
+        $sut = new class($descriptor) extends BaseField {
+            protected function validateCastValue($val)
+            {
+                // If the logic is wrong, this object will be in the error
+                // instead of the original date string.
+                return new \DateTimeImmutable($val);
+            }
+        };
+
+        $validatedValue = '2025-06-30';
+        $exception = null;
+
+        try {
+            $sut->castValue($validatedValue);
+        } catch (FieldValidationException $exception) {
+        }
+
+        self::assertNotNull($exception, 'An exception is expected for this test.');
+        self::assertSame(
+            'date_col: value is below minimum ("2025-06-30")',
+            $exception->getMessage()
+        );
+
+        $errors = $exception->validationErrors;
 
         self::assertCount(1, $errors);
         $error = reset($errors);


### PR DESCRIPTION
# Overview

This compliments #76, and ensures the original value is what is included in the exception when casting a value (not just when explicitly validating.)