### PR TITLE
ISSUE-78: Updates justinrainbow/json-schema to >=6.6 & fixes test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+                php-version: ['8.1','8.2','8.3']
                 composer-prefer:
                     - '--prefer-dist'
                     - '--prefer-stable --prefer-lowest'
@@ -17,7 +17,7 @@ jobs:
         name: Test PHP ${{ matrix.php-version }} / composer ${{matrix.composer-prefer}}
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v5
 
             - name: Setup PHP version ${{ matrix.php-version }}
               uses: shivammathur/setup-php@v2
@@ -45,7 +45,6 @@ jobs:
 
             - name: Run Code Style Check for PHP ${{ matrix.php-version }}
               run: composer run-script style-check
-              if: matrix.php-version != '7.1'
 
             - name: Run tests for PHP ${{ matrix.php-version }}
               run: composer run-script test
@@ -56,4 +55,4 @@ jobs:
               run: vendor/bin/php-coveralls
               env:
                   COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              if: success() && matrix.php-version == '7.4'
+              if: success() && matrix.php-version == '8.3'

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": ">=7.1.0",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "justinrainbow/json-schema": "^5.2.10",
+        "justinrainbow/json-schema": "^6.6",
         "nesbot/carbon": "^2.63.0",
         "jmikola/geojson": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A utility library for working with Table Schema",
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=8.0",
         "ext-mbstring": "*",
         "ext-json": "*",
         "justinrainbow/json-schema": "^6.6",
@@ -11,7 +11,7 @@
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=7.5 <10.0",
+        "phpunit/phpunit": ">=9.3 <10.0",
         "php-coveralls/php-coveralls": "^2.4",
         "psy/psysh": "@stable",
         "roave/security-advisories": "dev-latest"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php">
-    <php>
-        <ini name="display_errors" value="On" />
-        <ini name="error_reporting" value="24575" />
-    </php>
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <php>
+    <ini name="display_errors" value="On"/>
+    <ini name="error_reporting" value="24575"/>
+  </php>
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -11,12 +11,12 @@ class SchemaValidator
     /**
      * @var object
      */
-    private $descriptor;
+    protected $descriptor;
 
     /**
      * @var array
      */
-    private $errors;
+    protected $errors;
 
     /**
      * @param object $descriptor

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -584,9 +584,14 @@ JSON;
             'pointer' => '/0',
             // it considers file names to be invalid uris
             'message' => 'Invalid URL format',
-            'constraint' => 'format',
-            'context' => 1,
-            'format' => 'uri',
+            // Constraint errors are arrays since justinrainbow/json-schema:^6
+            'constraint' => [
+                'name' => 'urlFormat',
+                'params' => [
+                    'format' => 'uri'
+                ],
+            ],
+            'context' => 1
         ]], $validator->getErrors());
     }
 


### PR DESCRIPTION
# Overview

See #78 

Updates` justinrainbow/json-schema` and fixes test that depends on returned array from the error bag object on validation error (see `\JsonSchema\Entity\ErrorBag::addError`)
Also the phpunit schema was behind, this brings it up to 9.3

Schema Validator `descriptor` and `error `properties moved from private to protected. frictionlessdata/datapackage-php extends that class and needs access to those properties. If a better solution is to access plain accessors (e.g current errors accessor does internal revalidation so not suited for directly accessing already validated data), can do that too.


---

Please preserve this line to notify @courtney-miles (lead of this repository)
